### PR TITLE
Simplify travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,10 @@ rust: nightly
 os:
   - linux
   - osx
-env:
-  - ARCH=x86_64
-  - ARCH=i686
-addons:
-  apt:
-    packages:
-      - gcc-multilib
 cache: cargo
 sudo: false
 script: |
-  curl -sSL https://raw.githubusercontent.com/carllerche/travis-rust-matrix/master/test | bash
-  cargo test && cargo test --release
+  cargo test
   pushd plugin
   cargo test
   popd


### PR DESCRIPTION
Unlike overflower, we don't need to distinguish between usize widths, so we can get rid of the build matrix. Also there should be no difference between debug and release builds, so we can get rid of that, too. This should speed up the build somewhat.