### PR TITLE
WIP Add mutagen test runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 # will have compiled files and executables
 /target/
 /plugin/target/
+/runner/target/
 
 # Remove Cargo.lock from gitignore if creating an executable, leave it for libraries
 # More information here http://doc.crates.io/guide.html#cargotoml-vs-cargolock

--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ This project is basically an experiment to see what mutations we can still apply
 
 ### Running mutagen
 
-We plan to have a test runner at some point, but until we get there, you'll need to call mutagen manually.
-
 Again, remember you need a nightly `rustc` to compile the plugin. Add the plugin and helper library as a dev-dependency to your `Cargo.toml`:
 
 ```
@@ -50,6 +48,8 @@ Now you can advise mutagen to mutate any function, method, impl, trait impl or w
 ```
 
 This ensures the mutation will only be active in test mode. Now you can run `cargo test` as always, which will mutate your code and write a list of mutations in `target/mutagen/mutations.txt`. For every mutation, counting from one, you can run the test binary with the environment variable `MUTATION_COUNT=1 target/debug/myproj-123456`, `MUTATION_COUNT=2 ..`, etc.
+
+To automate this install the runner. Run `cargo install` in the runner dir. Compile the test for the project under test (`cargo +nightly test --no-run`). Run `cargo mutagen`.
 
 ### Contributing
 

--- a/examples/example_project/src/lib.rs
+++ b/examples/example_project/src/lib.rs
@@ -30,7 +30,7 @@ pub fn count_alphabetic_chars(c: char, string: &str) -> usize {
     let chars = string.chars().collect::<Vec<char>>();
 
     // Check if within bounds
-    if (ord < 0x41 || ord > 0x5A) && (ord < 0x71 || ord > 0x7A) {
+    if (ord < 0x41 || ord > 0x5A) && (ord < 0x61 || ord > 0x7A) {
         return 0;
     }
 
@@ -45,33 +45,93 @@ pub fn count_alphabetic_chars(c: char, string: &str) -> usize {
 
 #[cfg(test)]
 mod tests {
+    #![allow(non_snake_case)]
 
     use super::count_alphabetic_chars;
-    use super::mutagen;
 
     #[test]
     fn test_count_alphabetic_chars() {
         let string = "AsfwrgebrtSSNNfegerhLLSL4243";
-        let mut results = vec![];
 
-        for _ in 0..100 {
-            mutagen::next();
+        let result = count_alphabetic_chars('S', string);
+        assert_eq!(3, result);
+    }
 
-            //Actual test
-            let result = 3 == count_alphabetic_chars('S', string);
+    #[test]
+    fn test_count_lt_a() {
+        let string = "AsfwragebrtSSNNfegerhLLSL`4243";
 
-            println!(
-                "Test {}: {} == {} => {}",
-                mutagen::get(),
-                3,
-                count_alphabetic_chars('S', string),
-                result
-            );
+        let result = count_alphabetic_chars('`', string);
+        assert_eq!(0, result);
+    }
 
-            results.push(result);
-        }
+    #[test]
+    fn test_count_a() {
+        let string = "AsfwragebrtSSNNfegerhLLS1L4243";
 
-        // All results should be false
-        assert_eq!(true, results.iter().all(|x| !*x));
+        let result = count_alphabetic_chars('a', string);
+        assert_eq!(1, result);
+    }
+
+    #[test]
+    fn test_count_z() {
+        let string = "AsfwragebrtSSNNfegezrhLLSL4243";
+
+        let result = count_alphabetic_chars('z', string);
+        assert_eq!(1, result);
+    }
+
+    #[test]
+    fn test_count_gt_z() {
+        let string = "AsfwragebrtSSNNfegezrhLLS{L4243";
+
+        let result = count_alphabetic_chars('{', string);
+        assert_eq!(0, result);
+    }
+
+    #[test]
+    fn test_count_lt_A() {
+        let string = "AsfwragebrtSSNNfeg@erhLLSL4243";
+
+        let result = count_alphabetic_chars('@', string);
+        assert_eq!(0, result);
+    }
+
+    #[test]
+    fn test_count_A() {
+        let string = "AsfwragebrtSSNNfegerhLLSL4243";
+
+        let result = count_alphabetic_chars('A', string);
+        assert_eq!(1, result);
+    }
+
+    #[test]
+    fn test_count_Z() {
+        let string = "AsfwragebrtSSNNfegeZzrhLLSL4243";
+
+        let result = count_alphabetic_chars('Z', string);
+        assert_eq!(1, result);
+    }
+
+    #[test]
+    fn test_count_gt_Z() {
+        let string = "AsfwragebrtSSNNfegeZz[rhLLSL4243";
+
+        let result = count_alphabetic_chars('[', string);
+        assert_eq!(0, result);
+    }
+
+    #[test]
+    fn test_count_empty() {
+        let string = "";
+
+        assert_eq!(0, count_alphabetic_chars('S', string));
+    }
+
+    #[test]
+    fn test_count_non_ascii() {
+        let string = "Adwfwrec DW34542";
+
+        assert_eq!(0, count_alphabetic_chars(' ', string));
     }
 }

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "cargo-mutagen"
+version = "0.1.0"
+authors = ["Hmvp <github@hmvp.nl>"]
+description = "Mutation testing for Rust – Runner"
+repository = "https://github.com/llogiq/mutator"
+
+[dependencies]
+serde = "1.0"
+serde_derive = "1.0"
+serde_json = "1.0"

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -1,0 +1,129 @@
+#[macro_use]
+extern crate serde_derive;
+extern crate serde_json;
+
+use std::process::Command;
+use std::fs::File;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+static TARGET_MUTAGEN: &'static str = "target/mutagen";
+static MUTATIONS_LIST: &'static str = "mutations.txt";
+
+#[derive(Deserialize)]
+struct Metadata {
+    workspace_root: String,
+}
+
+fn run_mutation(i: usize) -> Result<String, String> {
+    let output = Command::new("cargo")
+        .args(&["test"])
+        // 0 is actually no mutations so we need i + 1 here
+        .env("MUTATION_COUNT", (i + 1).to_string())
+        .output()
+        .expect("failed to execute process");
+
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+
+    if output.status.success() {
+        Err(stdout)
+    } else {
+        Ok(stdout)
+    }
+}
+
+fn run_mutations(list: Vec<String>) {
+    let max_mutation = list.len();
+
+    let mut failures = Vec::new();
+
+    println!("Running {} mutations", max_mutation);
+    for i in 0..max_mutation {
+        print!("{}", list[i]);
+
+        let result = run_mutation(i);
+
+        if let Err(stdout) = result {
+            println!(" ... FAILED");
+            failures.push((&list[i], stdout))
+        } else {
+            //failures.push((&list[i], result.unwrap()));
+            println!(" ... ok");
+        }
+    }
+
+    if !failures.is_empty() {
+        println!("\nFailures:\n");
+
+        for &(ref mutation, ref failure) in &failures {
+            println!("---- {} stdout ----", mutation);
+            for line in failure.split("\n") {
+                println!("  {}", line);
+            }
+            println!("");
+        }
+
+        println!("\nFailures:\n");
+
+        for &(mutation, _) in &failures {
+            println!("\t{}", mutation);
+        }
+    }
+
+    println!(
+        "\nMutation results: {}. {} passed; {} failed",
+        if failures.is_empty() { "ok" } else { "FAILED" },
+        list.len() - failures.len(),
+        failures.len()
+    );
+}
+
+fn get_mutations_filename() -> PathBuf {
+    // TODO can we improve this without needing serde etc 
+    // to basically get the root dir of the crate?
+    let metadata = Command::new("cargo")
+        .args(&["metadata"])
+        .output()
+        .expect("failed to execute process")
+        .stdout;
+    let metadata: Metadata = serde_json::from_slice(&metadata).unwrap();
+    let root_dir = metadata.workspace_root;
+
+    let mutagen_dir = Path::new(&root_dir).join(TARGET_MUTAGEN);
+    if !mutagen_dir.exists() {
+        panic!("Mutations are missing");
+    }
+    mutagen_dir.join(MUTATIONS_LIST)
+}
+
+fn compile_tests() {
+    // TODO make this actually work
+    let compiled_tests = Command::new("cargo")
+        .args(&["test", "--no-run"])
+        .output()
+        .expect("failed to execute process")
+        .status
+        .success();
+
+    if !compiled_tests {
+        panic!("Could not compile tests");
+    }
+}
+
+fn read_mutations(filename: PathBuf) -> Vec<String> {
+    let mut file = File::open(filename).expect("Mutations are missing");
+    let mut s = String::new();
+    file.read_to_string(&mut s)
+        .expect("Failed reading mutations file");
+    s.split("\n")
+        .filter(|l| !l.is_empty())
+        .map(|l| l.to_string())
+        .collect()
+}
+
+fn main() {
+    compile_tests();
+    let filename = get_mutations_filename();
+    let list = read_mutations(filename);
+    run_mutations(list)
+}


### PR DESCRIPTION
Not finished yet but wanted the put it out here early to get feedback. This should solve #2.

This runs cargo test for every mutation and checks if at least one test fails

The idea is to run `cargo install` in the runner dir then run `cargo test && cargo mutagen` in the example dir

TODO:

- [ ] Cleanup unwraps
- [ ] Make sure the tests are compiled from the runner (you currently need to do that beforehand)
- [ ] Kill long running test suites
- [ ] Update example to only fail on one mutation as an example. It currently failes on many