### PR TITLE
Change the runner to find and run the test binary directly

### DIFF
--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-mutagen"
 version = "0.1.0"
-authors = ["Hmvp <github@hmvp.nl>"]
+authors = ["Hmvp <github@hmvp.nl>", "Andre Bogus <bogusandre@gmail.com>"]
 description = "Mutation testing for Rust – Runner"
 repository = "https://github.com/llogiq/mutator"
 


### PR DESCRIPTION
This parses the message output of `cargo test --no-run --message-format=json` to find out the location of the test binary to call it directly without the indirection through `cargo test`, which should be a bit faster.

I also added myself to the author list so I can publish cargo-mutagen on crates.io.