### PR TITLE
Add compiletest support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@ Cargo.lock
 **/*.rs.bk
 
 # Generated file from integration tests
-/plugin/tests/target/
+**/mutations.txt

--- a/plugin/Cargo.toml
+++ b/plugin/Cargo.toml
@@ -15,5 +15,8 @@ plugin = true
 [dependencies]
 mutagen = {"version" = "0.1.0", "path" = ".."}
 
+[dev-dependencies]
+compiletest_rs = "*"
+
 [badges]
 travis-ci = { repository = "llogiq/mutagen", branch = "master" }

--- a/plugin/tests/compile-fail/failing_eq_ne.rs
+++ b/plugin/tests/compile-fail/failing_eq_ne.rs
@@ -1,0 +1,13 @@
+#![feature(plugin)] //~ ERROR mismatched types [E0308]
+#![plugin(mutagen_plugin)]
+#![feature(custom_attribute)]
+extern crate mutagen;
+
+#[mutate] //~ ERROR mismatched types [E0308]
+fn eq_with_early_return() -> usize {
+    let a = 'a' == if true { 'b' } else { return 42 };
+
+    24322
+}
+
+fn main() {}

--- a/plugin/tests/compile-fail/issue-34.rs
+++ b/plugin/tests/compile-fail/issue-34.rs
@@ -1,0 +1,24 @@
+#![feature(plugin)]
+#![plugin(mutagen_plugin)]
+#![feature(custom_attribute)]
+
+extern crate mutagen;
+
+fn foo() -> usize { 2 }
+fn bar() -> usize { 23 }
+
+#[mutate]
+//~^ ERROR capture of possibly uninitialized variable: `value` [E0381]
+//~^^ ERROR cannot borrow `value` as mutable more than once at a time [E0499]
+fn blubb() -> usize {
+    let mut value;
+    if ({ value = foo(); value > 5 }) || ({ value = bar(); value < 5 }) {
+        value + 1 //~ ERROR use of possibly uninitialized variable: `value` [E0381]
+    } else {
+        42
+    }
+}
+
+fn main() {
+    println!("{}", blubb());
+}

--- a/plugin/tests/compile-test.rs
+++ b/plugin/tests/compile-test.rs
@@ -1,0 +1,20 @@
+extern crate compiletest_rs as compiletest;
+
+use std::path::PathBuf;
+
+fn run_mode(mode: &'static str) {
+    let mut config = compiletest::Config::default();
+
+    config.mode = mode.parse().expect("Invalid mode");
+    config.src_base = PathBuf::from(format!("tests/{}", mode));
+    config.link_deps(); // Populate config.target_rustcflags with dependencies on the path
+    config.clean_rmeta(); // If your tests import the parent crate, this helps with E0464
+
+    compiletest::run_tests(&config);
+}
+
+#[test]
+fn compile_test() {
+    run_mode("compile-fail");
+    run_mode("run-pass");
+}

--- a/plugin/tests/run-pass/test_eq_ne.rs
+++ b/plugin/tests/run-pass/test_eq_ne.rs
@@ -1,0 +1,22 @@
+#![feature(plugin)]
+#![plugin(mutagen_plugin)]
+#![feature(custom_attribute)]
+
+extern crate mutagen;
+
+fn main() {}
+
+#[mutate]
+fn simple() {
+    fn t() -> u32 {
+        5
+    }
+
+    if (42 == t()) {
+        // Do something
+    }
+
+    if (2 != 3) {
+        // Do something
+    }
+}


### PR DESCRIPTION
Adding compiletest library and adding an example for eq and ne mutations
that are applied properly.

Related to: https://github.com/llogiq/mutagen/issues/37

On the other hand, I'm adding some tests that currently are failing (on
the compile-fail folder) that we should fix at some time. I think it
may be useful to keep track of the issues pending to be fixed and it
will help to not add regressions of known patterns that caused issues on
the past.

@llogiq @hmvp I'm not sure about keeping track of the "compile-fail" tests. What do you think?