### PR TITLE
simplify mutagen lib

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,224 +54,175 @@ pub struct Mutagen {
 
 impl Mutagen {
     /// get the current mutation count
+    #[inline]
     pub fn get(&self) -> usize {
         self.x.load(Ordering::Relaxed)
     }
 
-    /// check if the argument matches the current mutation count
-    ///
-    /// this simplifies operations like `if mutagen::MU.now(42) { .. }`
-    pub fn now(&self, n: usize) -> bool {
-        self.get() == n
-    }
-
     /// increment the mutation count
+    #[inline]
     pub fn next(&self) {
         //TODO: clamp at maximum, return Option<usize>, impl Iterator?
         self.x.fetch_add(1, Ordering::SeqCst);
     }
 
-    /// insert the original or an alternate value, e.g. `MU.select(&[2, 0], 42)`
-    pub fn select<T, S: Selector<T>>(&self, selector: S, n: usize) -> T {
-        selector.get(self.get().wrapping_sub(n))
-    }
-
-    /// use with if expressions, e.g. `if MU.t(..) { .. } else { .. }`
-    pub fn t(&self, t: bool, n: usize) -> bool {
-        match self.get().wrapping_sub(n) {
-            0 => true,
-            1 => false,
-            2 => !t,
-            _ => t
-        }
-    }
-
-    /// use with while expressions, e.g. `while Mu.w(..) { .. }`
-    ///
-    /// this never leads to infinite loops
-    pub fn w(&self, t: bool, n: usize) -> bool {
-        if self.get() == n { false } else { t }
-    }
-
-    /// use instead of `&&`
-    ///
-    /// upholds the invariant that g() is not called unless f() == true
-    pub fn and<X, Y>(&self, f: X, g: Y, n: usize) -> bool
-        where X: FnOnce() -> bool, Y: FnOnce() -> bool {
-        match self.get().wrapping_sub(n) {
-            0 => false,
-            1 => true,
-            2 => f(),
-            3 => !f(),
-            4 => f() && !g(),
-            _ => f() && g()
-        }
-    }
-
-    /// use instead of `||`
-    ///
-    /// upholds the invariant that g() is not called unless f() == false
-    pub fn or<X, Y>(&self, f: X, g: Y, n: usize) -> bool
-        where X: FnOnce() -> bool, Y: FnOnce() -> bool {
-        match self.get().wrapping_sub(n) {
-            0 => false,
-            1 => true,
-            2 => f(),
-            3 => !f(),
-            4 => f() || !g(),
-            _ => f() || g()
-        }
-    }
-
-    /// use instead of `==`
-    pub fn eq<X, Y, T: PartialEq>(&self, x: X, y: Y, n: usize) -> bool
-    where X: FnOnce() -> T, Y: FnOnce() -> T {
-        match self.get().wrapping_sub(n) {
-            0 => true,
-            1 => false,
-            2 => x() != y(),
-            _ => x() == y()
-        }
-    }
-
-    /// use instead of `!=`
-    pub fn ne<X, Y, T: PartialEq>(&self, x: X, y: Y, n: usize) -> bool
-        where X: FnOnce() -> T, Y: FnOnce() -> T {
-        match self.get().wrapping_sub(n) {
-            0 => true,
-            1 => false,
-            2 => x() == y(),
-            _ => x() != y()
-        }
-    }
-
-    /// use instead of `>` (or, switching operand order `<`)
-    pub fn gt<X, Y, T: PartialOrd>(&self, x: X, y: Y, n: usize) -> bool
-        where X: FnOnce() -> T, Y: FnOnce() -> T {
-        match self.get().wrapping_sub(n) {
-            0 => false,
-            1 => true,
-            2 => x() < y(),
-            3 => x() <= y(),
-            4 => x() >= y(),
-            5 => {
-                let xv = x();
-                let yv = y();
-                xv <= yv && xv >= yv
-            }, // == with PartialOrd
-            6 => {
-                let xv = x();
-                let yv = y();
-
-                xv < yv || xv > yv
-            }, // != with PartialOrd
-            _ => x() > y()
-        }
-    }
-
-    /// use instead of `>=` (or, switching operand order `<=`)
-    pub fn ge<X, Y, T: PartialOrd>(&self, x: X, y: Y, n: usize) -> bool
-        where X: FnOnce() -> T, Y: FnOnce() -> T {
-        match self.get().wrapping_sub(n) {
-            0 => false,
-            1 => true,
-            2 => x() < y(),
-            3 => x() <= y(),
-            4 => x() > y(),
-            5 => {
-                let xv = x();
-                let yv = y();
-                xv <= yv && xv >= yv
-            }, // == with PartialOrd
-            6 => {
-                let xv = x();
-                let yv = y();
-
-                xv < yv || xv > yv
-            }, // != with PartialOrd
-            _ => x() >= y()
-        }
+    /// reset the mutation count to 0
+    #[inline]
+    pub fn reset(&self) {
+        self.x.store(0, Ordering::SeqCst);
     }
 }
 
 /// get the current mutation count
+#[inline]
 pub fn get() -> usize {
     MU.get()
+}
+
+/// increment the mutation count
+#[inline]
+pub fn next() {
+    MU.next()
+}
+
+/// reset the mutation count to 0 (for testing)
+#[inline]
+pub fn reset() {
+    MU.reset()
 }
 
 /// check if the argument matches the current mutation count
 ///
 /// this simplifies operations like `if mutagen::MU.now(42) { .. }`
+#[inline]
 pub fn now(n: usize) -> bool {
-    MU.now(n)
+    MU.get() == n
 }
 
-/// increment the mutation count
-pub fn next() {
-    MU.next()
+/// get the wrapping difference between the given count and the current
+/// mutation count
+#[inline]
+pub fn diff(n: usize) -> usize {
+    MU.get().wrapping_sub(n)
 }
 
 /// insert the original or an alternate value, e.g. `MU.select(&[2, 0], 42)`
+#[inline]
 pub fn select<T, S: Selector<T>>(selector: S, n: usize) -> T {
-    MU.select(selector, n)
+    selector.get(diff(n))
 }
 
 /// use with if expressions, e.g. `if MU.t(..) { .. } else { .. }`
+#[inline]
 pub fn t(t: bool, n: usize) -> bool {
-    MU.t(t, n)
+    match diff(n) {
+        0 => true,
+        1 => false,
+        2 => !t,
+        _ => t
+    }
 }
 
 /// use with while expressions, e.g. `while Mu.w(..) { .. }`
 ///
 /// this never leads to infinite loops
+#[inline]
 pub fn w(t: bool, n: usize) -> bool {
-    MU.w(t, n)
+    if now(n) { false } else { t }
 }
 
 /// use instead of `&&`
 ///
 /// upholds the invariant that g() is not called unless f() == true
+#[inline]
 pub fn and<X, Y>(f: X, g: Y, n: usize) -> bool
 where
     X: FnOnce() -> bool,
     Y: FnOnce() -> bool,
 {
-    MU.and(f, g, n)
+    match diff(n) {
+        0 => false,
+        1 => true,
+        2 => f(),
+        3 => !f(),
+        4 => f() && !g(),
+        _ => f() && g()
+    }
 }
 
 /// use instead of `||`
 ///
 /// upholds the invariant that g() is not called unless f() == false
+#[inline]
 pub fn or<X, Y>(f: X, g: Y, n: usize) -> bool
 where
     X: FnOnce() -> bool,
     Y: FnOnce() -> bool,
 {
-    MU.or(f, g, n)
+    match diff(n) {
+        0 => false,
+        1 => true,
+        2 => f(),
+        3 => !f(),
+        4 => f() || !g(),
+        _ => f() || g()
+    }
 }
 
 /// use instead of `==`
+#[inline]
 pub fn eq<X, Y, T: PartialEq>(x: X, y: Y, n: usize) -> bool
     where X: FnOnce() -> T, Y: FnOnce() -> T {
-    MU.eq(x, y, n)
+    match diff(n) {
+        0 => true,
+        1 => false,
+        2 => x() != y(),
+        _ => x() == y()
+    }
 }
 
 /// use instead of `!=`
+#[inline]
 pub fn ne<X, Y, T: PartialEq>(x: X, y: Y, n: usize) -> bool
     where X: FnOnce() -> T, Y: FnOnce() -> T {
-    MU.ne(x, y, n)
+    match diff(n) {
+        0 => true,
+        1 => false,
+        2 => x() == y(),
+        _ => x() != y()
+    }
 }
 
 /// use instead of `>` (or, switching operand order `<`)
+#[inline]
 pub fn gt<X, Y, T: PartialOrd>(x: X, y: Y, n: usize) -> bool
     where X: FnOnce() -> T, Y: FnOnce() -> T {
-    MU.gt(x, y, n)
+    match diff(n) {
+        0 => false,
+        1 => true,
+        2 => x() < y(),
+        3 => x() <= y(),
+        4 => x() >= y(),
+        5 => x() == y(),
+        6 => x() != y(),
+        _ => x() > y()
+    }
 }
 
 /// use instead of `>=` (or, switching operand order `<=`)
+#[inline]
 pub fn ge<X, Y, T: PartialOrd>(x: X, y: Y, n: usize) -> bool
     where X: FnOnce() -> T, Y: FnOnce() -> T {
-    MU.ge(x, y, n)
+    match diff(n) {
+        0 => false,
+        1 => true,
+        2 => x() < y(),
+        3 => x() <= y(),
+        4 => x() > y(),
+        5 => x() == y(),
+        6 => x() != y(),
+        _ => x() >= y()
+    }
 }
 
 #[cfg(test)]
@@ -280,45 +231,43 @@ mod tests {
 
     #[test]
     fn eq_mutation() {
-        let mu = Mutagen { x: AtomicUsize::new(0) };
-
+        reset();
         // Always true
-        assert_eq!(true, mu.eq(|| 1, || 0, 0));
+        assert_eq!(true, eq(|| 1, || 0, 0));
 
         // Always false
-        mu.next();
-        assert_eq!(false, mu.eq(|| 1, || 0, 0));
+        next();
+        assert_eq!(false, eq(|| 1, || 0, 0));
 
         // Checks inequality
-        mu.next();
-        assert_eq!(true, mu.eq(|| 0, || 1, 0));
-        assert_eq!(false, mu.eq(|| 1, || 1, 0));
+        next();
+        assert_eq!(true, eq(|| 0, || 1, 0));
+        assert_eq!(false, eq(|| 1, || 1, 0));
 
         // Checks equality
-        mu.next();
-        assert_eq!(true, mu.eq(|| 0, || 0, 0));
-        assert_eq!(false, mu.eq(|| 1, || 0, 0));
+        next();
+        assert_eq!(true, eq(|| 0, || 0, 0));
+        assert_eq!(false, eq(|| 1, || 0, 0));
     }
 
     #[test]
     fn ne_mutation() {
-        let mu = Mutagen { x: AtomicUsize::new(0) };
-
+        reset();
         // Always true
-        assert_eq!(true, mu.ne(|| 1, || 0, 0));
+        assert_eq!(true, ne(|| 1, || 0, 0));
 
         // Always false
-        mu.next();
-        assert_eq!(false, mu.ne(|| 1, || 0, 0));
+        next();
+        assert_eq!(false, ne(|| 1, || 0, 0));
 
         // Checks equality
-        mu.next();
-        assert_eq!(false, mu.ne(|| 0, || 1, 0));
-        assert_eq!(true, mu.ne(|| 1, || 1, 0));
+        next();
+        assert_eq!(false, ne(|| 0, || 1, 0));
+        assert_eq!(true, ne(|| 1, || 1, 0));
 
         // Checks inequality
-        mu.next();
-        assert_eq!(false, mu.ne(|| 0, || 0, 0));
-        assert_eq!(true, mu.ne(|| 1, || 0, 0));
+        next();
+        assert_eq!(false, ne(|| 0, || 0, 0));
+        assert_eq!(true, ne(|| 1, || 0, 0));
     }
 }


### PR DESCRIPTION
This pushes most od the code outside the `Mutagen` object and adds a `reset` method to ease testing.

I'm unsure if we should expose this method (or `next()`), but it currently seems the best way forward.