### PR TITLE
harden plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ Cargo.lock
 
 # Generated file from integration tests
 **/mutations.txt
+
+# Generated file from build script
+/src/ops.rs

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,98 @@
+use std::fs::File;
+use std::io::{Write, BufWriter, Result};
+
+fn write_binop(out: &mut Write, o_trait: &str, o_fn: &str, mut_trait: &str, mut_fn: &str) ->
+    Result<()> {
+    writeln!(out, "
+pub trait {0}{2}<Rhs = Self> {{
+    type Output;
+    fn {1}(self, rhs: Rhs, mutation_count: usize) -> Self::Output;
+}}
+
+impl<T, Rhs> {0}{2}<Rhs> for T
+where T: {0}<Rhs> {{
+    type Output = <T as {0}<Rhs>>::Output;
+    default fn {1}(self, rhs: Rhs, _mutation_count: usize) -> Self::Output {{
+        {0}::{1}(self, rhs)
+    }}
+}}
+
+impl<T, Rhs> {0}{2}<Rhs> for T
+where T: {0}<Rhs>,
+      T: {2}<Rhs>,
+     <T as {2}<Rhs>>::Output: Into<<T as {0}<Rhs>>::Output> {{
+    fn {1}(self, rhs: Rhs, mutation_count: usize) -> Self::Output {{
+        if super::now(mutation_count) {{
+            {2}::{3}(self, rhs).into()
+        }} else {{
+            {0}::{1}(self, rhs)
+        }}
+    }}
+}}
+", o_trait, o_fn, mut_trait, mut_fn)
+}
+
+static BINOP_PAIRS: &[[&str; 4]] = &[
+    ["Add", "add", "Sub", "sub"],
+    ["Mul", "mul", "Div", "div"],
+    ["Shl", "shl", "Shr", "shr"],
+    ["BitAnd", "bitand", "BitOr", "bitor"],
+    ["BitXor", "bitxor", "BitOr", "bitor"],
+    ["BitAnd", "bitand", "BitXor", "bitxor"],
+];
+
+fn write_unop(out: &mut Write, op_trait: &str, op_fn: &str) -> Result<()> {
+    writeln!(out, "
+pub trait May{0} {{
+    type Output;
+    fn {1}(self, mutation_count: usize) -> Self::Output;
+}}
+
+impl<T> May{0} for T where T: {0} {{
+    type Output = <T as {0}>::Output;
+    default fn {1}(self, _mutation_count: usize) -> Self::Output {{
+        {0}::{1}(self)
+    }}
+}}
+
+impl<T> May{0} for T where T: {0}, T: Into<<T as {0}>::Output> {{
+    fn {1}(self, mutation_count: usize) -> Self::Output {{
+        if super::now(mutation_count) {{ self.into() }} else {{ {0}::{1}(self) }}
+    }}
+}}
+", op_trait, op_fn)
+}
+
+fn write_ops() -> Result<()> {
+    let mut f = File::create("src/ops.rs")?;
+    let mut out = BufWriter::new(&mut f);
+    writeln!(out, "use std::ops::*;
+")?;
+    for names in BINOP_PAIRS.iter() {
+        write_binop(&mut out, names[0], names[1], names[2], names[3])?;
+        write_binop(&mut out, names[2], names[3], names[0], names[1])?;
+    }
+    for &(ref op_trait, ref op_fn) in [("Not", "not"), ("Neg", "neg")].iter() {
+        write_unop(&mut out, op_trait, op_fn)?;
+    }
+    writeln!(out, "
+pub trait MayClone<T> {{
+    fn may_clone(&self) -> bool;
+    fn clone(&self) -> Self;
+}}
+
+impl<T> MayClone<T> for T {{
+    default fn may_clone(&self) -> bool {{ false }}
+    default fn clone(&self) -> Self {{ unimplemented!() }}
+}}
+
+impl<T: Clone> MayClone<T> for T {{
+    fn may_clone(&self) -> bool {{ true }}
+    fn clone(&self) -> Self {{ self.clone() }}
+}}")?;
+    out.flush()
+}
+
+fn main() {
+    write_ops().unwrap();
+}

--- a/plugin/src/lib.rs
+++ b/plugin/src/lib.rs
@@ -349,7 +349,7 @@ impl<'a, 'cx> Folder for MutatorPlugin<'a, 'cx> {
                     }
                     let left = self.fold_expr(left);
                     let right = self.fold_expr(right);
-                    quote_expr!(self.cx, 
+                    quote_expr!(self.cx,
                                 (match ($left, ::mutagen::diff($n)) {
                                         (_, 0) => false,
                                         (_, 1) => true,
@@ -378,7 +378,7 @@ impl<'a, 'cx> Folder for MutatorPlugin<'a, 'cx> {
                     }
                     let left = self.fold_expr(left);
                     let right = self.fold_expr(right);
-                    quote_expr!(self.cx, 
+                    quote_expr!(self.cx,
                                 (match ($left, ::mutagen::diff($n)) {
                                         (_, 0) => false,
                                         (_, 1) => true,

--- a/plugin/src/lib.rs
+++ b/plugin/src/lib.rs
@@ -16,7 +16,7 @@ use syntax::fold::{self, Folder};
 use syntax::ptr::P;
 use syntax::symbol::Symbol;
 use syntax::util::small_vector::SmallVector;
-use syntax::ast::{LitKind, LitIntType, IntTy, UnOp};
+use syntax::ast::{IntTy, LitIntType, LitKind, UnOp};
 
 #[plugin_registrar]
 pub fn plugin_registrar(reg: &mut Registry) {
@@ -26,9 +26,9 @@ pub fn plugin_registrar(reg: &mut Registry) {
     );
 }
 
-static TARGET_MUTAGEN : &'static str = "target/mutagen";
-static MUTATIONS_LIST : &'static str = "mutations.txt";
-static MUTATION_COUNT : AtomicUsize = AtomicUsize::new(0);
+static TARGET_MUTAGEN: &'static str = "target/mutagen";
+static MUTATIONS_LIST: &'static str = "mutations.txt";
+static MUTATION_COUNT: AtomicUsize = AtomicUsize::new(0);
 
 /// create a MutatorPlugin and let it fold the items/trait items/impl items
 pub fn mutator(cx: &mut ExtCtxt, _span: Span, _mi: &MetaItem, a: Annotatable) -> Annotatable {
@@ -121,7 +121,10 @@ impl<'a, 'cx> MutatorPlugin<'a, 'cx> {
         for arg in &decl.inputs {
             if let Some((name, mutability)) = get_pat_name_mut(&arg.pat) {
                 argtypes.insert(name, (mutability, &*arg.ty));
-                typeargs.entry((mutability, &arg.ty)).or_insert(vec![]).push(name);
+                typeargs
+                    .entry((mutability, &arg.ty))
+                    .or_insert(vec![])
+                    .push(name);
                 if Some(&*arg.ty) == out_ty {
                     have_output_type.push(name);
                 }
@@ -132,14 +135,18 @@ impl<'a, 'cx> MutatorPlugin<'a, 'cx> {
             if typeargs[&mut_ty].len() > 1 {
                 interchangeables.insert(
                     arg,
-                    typeargs[&mut_ty].iter().cloned().filter(|a| a != &arg).collect(),
+                    typeargs[&mut_ty]
+                        .iter()
+                        .cloned()
+                        .filter(|a| a != &arg)
+                        .collect(),
                 );
             }
         }
         self.info.method_infos.push(MethodInfo {
             is_default,
             have_output_type,
-            interchangeables
+            interchangeables,
         });
     }
 
@@ -157,9 +164,13 @@ impl<'a, 'cx> MutatorPlugin<'a, 'cx> {
         assert!(ty.is_some());
     }
 
-    fn mutate_numeric_constant_expression(&mut self, lit: &Lit, is_negative: bool) -> Option<P<Expr>> {
+    fn mutate_numeric_constant_expression(
+        &mut self,
+        lit: &Lit,
+        is_negative: bool,
+    ) -> Option<P<Expr>> {
         match lit {
-            &Spanned{
+            &Spanned {
                 node: LitKind::Int(i, ty),
                 span: s,
             } => {
@@ -179,9 +190,7 @@ impl<'a, 'cx> MutatorPlugin<'a, 'cx> {
                             &mut self.mutations,
                             &mut self.current_count,
                             s,
-                            &[
-                                "sub one to int constant",
-                            ],
+                            &["sub one to int constant"],
                         );
                     }
 
@@ -201,9 +210,7 @@ impl<'a, 'cx> MutatorPlugin<'a, 'cx> {
                             &mut self.mutations,
                             &mut self.current_count,
                             s,
-                            &[
-                                "add one to int constant",
-                            ],
+                            &["add one to int constant"],
                         );
                     }
 
@@ -215,10 +222,8 @@ impl<'a, 'cx> MutatorPlugin<'a, 'cx> {
                 }
 
                 Some(mut_expression)
-            },
-            _ => {
-                None
             }
+            _ => None,
         }
     }
 }
@@ -246,7 +251,7 @@ impl<'a, 'cx> Folder for MutatorPlugin<'a, 'cx> {
                 generics,
                 node: TraitItemKind::Method(sig, Some(block)),
                 span,
-                tokens
+                tokens,
             } => {
                 self.start_fn(&sig.decl);
                 let ti = TraitItem {
@@ -256,36 +261,59 @@ impl<'a, 'cx> Folder for MutatorPlugin<'a, 'cx> {
                     generics,
                     node: TraitItemKind::Method(sig, Some(fold_first_block(block, self))),
                     span,
-                    tokens
+                    tokens,
                 };
                 self.end_fn();
                 ti
-            },
-            ti => ti
+            }
+            ti => ti,
         })
     }
 
     fn fold_item_kind(&mut self, i: ItemKind) -> ItemKind {
         match i {
-            ItemKind::Impl(unsafety, polarity, defaultness, generics, opt_trait_ref, ty, impl_items) => {
-                self.start_impl( & ty);
-                let k = ItemKind::Impl(unsafety, polarity, defaultness, generics, opt_trait_ref, ty, impl_items);
+            ItemKind::Impl(
+                unsafety,
+                polarity,
+                defaultness,
+                generics,
+                opt_trait_ref,
+                ty,
+                impl_items,
+            ) => {
+                self.start_impl(&ty);
+                let k = ItemKind::Impl(
+                    unsafety,
+                    polarity,
+                    defaultness,
+                    generics,
+                    opt_trait_ref,
+                    ty,
+                    impl_items,
+                );
                 self.end_impl();
                 k
-            },
+            }
             ItemKind::Fn(decl, unsafety, constness, abi, generics, block) => {
                 self.start_fn(&decl);
-                let k = ItemKind::Fn(decl, unsafety, constness, abi, generics, fold_first_block(block, self));
+                let k = ItemKind::Fn(
+                    decl,
+                    unsafety,
+                    constness,
+                    abi,
+                    generics,
+                    fold_first_block(block, self),
+                );
                 self.end_fn();
                 k
-            },
-            k => k
+            }
+            k => k,
         }
     }
 
     fn fold_expr(&mut self, expr: P<Expr>) -> P<Expr> {
         expr.and_then(|expr| match expr {
-            e@Expr {
+            e @ Expr {
                 id: _,
                 node: ExprKind::Mac(_),
                 span: _,
@@ -321,7 +349,14 @@ impl<'a, 'cx> Folder for MutatorPlugin<'a, 'cx> {
                     }
                     let left = self.fold_expr(left);
                     let right = self.fold_expr(right);
-                    quote_expr!(self.cx, ::mutagen::and(|| $left, || $right, $n))
+                    quote_expr!(self.cx, 
+                                (match ($left, ::mutagen::diff($n)) {
+                                        (_, 0) => false,
+                                        (_, 1) => true,
+                                        (x, 2) => x,
+                                        (x, 3) => !x,
+                                        (x, n) => x && ($right) == (n != 4),
+                                }))
                 }
                 BinOpKind::Or => {
                     let n;
@@ -343,7 +378,14 @@ impl<'a, 'cx> Folder for MutatorPlugin<'a, 'cx> {
                     }
                     let left = self.fold_expr(left);
                     let right = self.fold_expr(right);
-                    quote_expr!(self.cx, ::mutagen::or(|| $left, || $right, $n))
+                    quote_expr!(self.cx, 
+                                (match ($left, ::mutagen::diff($n)) {
+                                        (_, 0) => false,
+                                        (_, 1) => true,
+                                        (x, 2) => x,
+                                        (x, 3) => !x,
+                                        (x, n) => x || ($right) == (n != 4),
+                                }))
                 }
                 BinOpKind::Eq => {
                     let n;
@@ -363,7 +405,7 @@ impl<'a, 'cx> Folder for MutatorPlugin<'a, 'cx> {
                     }
                     let left = self.fold_expr(left);
                     let right = self.fold_expr(right);
-                    quote_expr!(self.cx, ::mutagen::eq(|| $left, || $right, $n))
+                    quote_expr!(self.cx, ::mutagen::eq($left, $right, $n))
                 }
                 BinOpKind::Ne => {
                     let n;
@@ -383,7 +425,7 @@ impl<'a, 'cx> Folder for MutatorPlugin<'a, 'cx> {
                     }
                     let left = self.fold_expr(left);
                     let right = self.fold_expr(right);
-                    quote_expr!(self.cx, ::mutagen::ne(|| $left, || $right, $n))
+                    quote_expr!(self.cx, ::mutagen::ne($left, $right, $n))
                 }
                 BinOpKind::Gt => {
                     let n;
@@ -407,7 +449,7 @@ impl<'a, 'cx> Folder for MutatorPlugin<'a, 'cx> {
                     }
                     let left = self.fold_expr(left);
                     let right = self.fold_expr(right);
-                    quote_expr!(self.cx, ::mutagen::gt(|| $left, || $right, $n))
+                    quote_expr!(self.cx, ::mutagen::gt($left, $right, $n))
                 }
                 BinOpKind::Lt => {
                     let n;
@@ -431,7 +473,7 @@ impl<'a, 'cx> Folder for MutatorPlugin<'a, 'cx> {
                     }
                     let left = self.fold_expr(left);
                     let right = self.fold_expr(right);
-                    quote_expr!(self.cx, ::mutagen::gt(|| $right, || $left, $n))
+                    quote_expr!(self.cx, ::mutagen::gt($right, $left, $n))
                 }
                 BinOpKind::Ge => {
                     let n;
@@ -455,7 +497,7 @@ impl<'a, 'cx> Folder for MutatorPlugin<'a, 'cx> {
                     }
                     let left = self.fold_expr(left);
                     let right = self.fold_expr(right);
-                    quote_expr!(self.cx, ::mutagen::ge(|| $left, || $right, $n))
+                    quote_expr!(self.cx, ::mutagen::ge($left, $right, $n))
                 }
                 BinOpKind::Le => {
                     let n;
@@ -479,7 +521,7 @@ impl<'a, 'cx> Folder for MutatorPlugin<'a, 'cx> {
                     }
                     let left = self.fold_expr(left);
                     let right = self.fold_expr(right);
-                    quote_expr!(self.cx, ::mutagen::ge(|| $right, || $left, $n))
+                    quote_expr!(self.cx, ::mutagen::ge($right, $left, $n))
                 }
                 _ => P(fold::noop_fold_expr(
                     Expr {
@@ -509,7 +551,7 @@ impl<'a, 'cx> Folder for MutatorPlugin<'a, 'cx> {
                             "replacing if condition with true",
                             "replacing if condition with false",
                             "inverting if condition",
-                        ]
+                        ],
                     );
                 }
                 let cond = self.fold_expr(cond);
@@ -520,7 +562,7 @@ impl<'a, 'cx> Folder for MutatorPlugin<'a, 'cx> {
                     id,
                     node: ExprKind::If(mut_cond, then, opt_else),
                     span,
-                    attrs
+                    attrs,
                 })
             }
             Expr {
@@ -537,7 +579,7 @@ impl<'a, 'cx> Folder for MutatorPlugin<'a, 'cx> {
                         &mut self.mutations,
                         &mut self.current_count,
                         cond.span,
-                        &["replacing while condition with false"]
+                        &["replacing while condition with false"],
                     );
                 }
                 let cond = self.fold_expr(cond);
@@ -547,9 +589,9 @@ impl<'a, 'cx> Folder for MutatorPlugin<'a, 'cx> {
                     id,
                     node: ExprKind::While(mut_cond, block, opt_label),
                     span,
-                    attrs
+                    attrs,
                 })
-            },
+            }
             Expr {
                 id,
                 node: ExprKind::Unary(UnOp::Neg, exp),
@@ -560,13 +602,11 @@ impl<'a, 'cx> Folder for MutatorPlugin<'a, 'cx> {
                     let maybe_exp = match &e.node {
                         &ExprKind::Lit(ref lit) => {
                             self.mutate_numeric_constant_expression(&lit, true)
-                        },
+                        }
                         _ => None,
                     };
 
-                    maybe_exp.unwrap_or_else(|| {
-                        P(e)
-                    })
+                    maybe_exp.unwrap_or_else(|| P(e))
                 });
 
                 P(Expr {
@@ -575,7 +615,7 @@ impl<'a, 'cx> Folder for MutatorPlugin<'a, 'cx> {
                     span,
                     attrs,
                 })
-            },
+            }
             Expr {
                 id,
                 node: ExprKind::Lit(lit),
@@ -584,20 +624,19 @@ impl<'a, 'cx> Folder for MutatorPlugin<'a, 'cx> {
             } => {
                 let exp = lit.and_then(|l| {
                     self.mutate_numeric_constant_expression(&l, false)
-                        .unwrap_or_else(|| P(Expr{
-                            id,
-                            node: ExprKind::Lit(P(l)),
-                            span,
-                            attrs,
-                        }))
+                        .unwrap_or_else(|| {
+                            P(Expr {
+                                id,
+                                node: ExprKind::Lit(P(l)),
+                                span,
+                                attrs,
+                            })
+                        })
                 });
 
                 exp
-
-            },
-            e => {
-                P(fold::noop_fold_expr(e, self))
-            },
+            }
+            e => P(fold::noop_fold_expr(e, self)),
         }) //TODO: more expr mutations
     }
 
@@ -606,7 +645,7 @@ impl<'a, 'cx> Folder for MutatorPlugin<'a, 'cx> {
     }
 }
 
-fn int_constant_can_subtract_one(i: i64, ty: LitIntType) -> bool{
+fn int_constant_can_subtract_one(i: i64, ty: LitIntType) -> bool {
     let min: i64 = match ty {
         LitIntType::Unsuffixed | LitIntType::Unsigned(_) => 0,
         LitIntType::Signed(IntTy::Isize) => std::i32::MIN as i64,
@@ -652,7 +691,8 @@ fn fold_first_block(block: P<Block>, m: &mut MutatorPlugin) -> P<Block> {
             is_default,
             ref have_output_type,
             ref interchangeables,
-        }) = info.method_infos.last() {
+        }) = info.method_infos.last()
+        {
             if is_default {
                 let n = *current_count;
                 add_mutations(
@@ -701,11 +741,7 @@ fn fold_first_block(block: P<Block>, m: &mut MutatorPlugin) -> P<Block> {
              }| {
                 let mut newstmts: Vec<Stmt> = Vec::with_capacity(pre_stmts.len() + stmts.len());
                 newstmts.extend(pre_stmts);
-                newstmts.extend(
-                    stmts
-                        .into_iter()
-                        .flat_map(|s| fold::noop_fold_stmt(s, m)),
-                );
+                newstmts.extend(stmts.into_iter().flat_map(|s| fold::noop_fold_stmt(s, m)));
                 Block {
                     stmts: newstmts,
                     id,
@@ -734,7 +770,12 @@ fn add_mutations(
 
 fn get_pat_name_mut(pat: &Pat) -> Option<(Symbol, Mutability)> {
     if let PatKind::Ident(mode, i, _) = pat.node {
-        Some((i.node.name, match mode { BindingMode::ByRef(m) | BindingMode::ByValue(m) => m }))
+        Some((
+            i.node.name,
+            match mode {
+                BindingMode::ByRef(m) | BindingMode::ByValue(m) => m,
+            },
+        ))
     } else {
         None
     }
@@ -906,14 +947,18 @@ fn get_lit(expr: &Expr) -> Option<usize> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use syntax::ast::{LitIntType, IntTy};
+    use syntax::ast::{IntTy, LitIntType};
 
     #[test]
     fn test_can_add_one() {
         let examples = [
             ((std::u8::MAX as u64) + 1, LitIntType::Unsuffixed, false),
             ((std::u8::MAX as u64) - 1, LitIntType::Unsuffixed, true),
-            ((std::i64::MAX as u64), LitIntType::Signed(IntTy::I64), false),
+            (
+                (std::i64::MAX as u64),
+                LitIntType::Signed(IntTy::I64),
+                false,
+            ),
             ((std::u64::MAX) - 1, LitIntType::Unsigned(UintTy::U64), true),
         ];
 
@@ -932,7 +977,11 @@ mod tests {
             (std::i8::MIN as i64, LitIntType::Signed(IntTy::I8), false),
             (std::i8::MIN as i64 + 1, LitIntType::Signed(IntTy::I8), true),
             (std::i64::MIN as i64, LitIntType::Signed(IntTy::I64), false),
-            (std::i64::MIN as i64 + 1, LitIntType::Signed(IntTy::I64), true),
+            (
+                std::i64::MIN as i64 + 1,
+                LitIntType::Signed(IntTy::I64),
+                true,
+            ),
         ];
 
         examples.iter().for_each(|test| {

--- a/plugin/tests/run-pass/failing_eq_ne.rs
+++ b/plugin/tests/run-pass/failing_eq_ne.rs
@@ -1,9 +1,9 @@
-#![feature(plugin)] //~ ERROR mismatched types [E0308]
+#![feature(plugin)]
 #![plugin(mutagen_plugin)]
 #![feature(custom_attribute)]
 extern crate mutagen;
 
-#[mutate] //~ ERROR mismatched types [E0308]
+#[mutate]
 fn eq_with_early_return() -> usize {
     let a = 'a' == if true { 'b' } else { return 42 };
 

--- a/plugin/tests/run-pass/issue-34.rs
+++ b/plugin/tests/run-pass/issue-34.rs
@@ -8,12 +8,10 @@ fn foo() -> usize { 2 }
 fn bar() -> usize { 23 }
 
 #[mutate]
-//~^ ERROR capture of possibly uninitialized variable: `value` [E0381]
-//~^^ ERROR cannot borrow `value` as mutable more than once at a time [E0499]
 fn blubb() -> usize {
     let mut value;
     if ({ value = foo(); value > 5 }) || ({ value = bar(); value < 5 }) {
-        value + 1 //~ ERROR use of possibly uninitialized variable: `value` [E0381]
+        value + 1
     } else {
         42
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(specialization)]
 /// Welcome to the mutagen crate. Your entry point will probably be cargo-mutagen, so install it
 /// right away.
 #[macro_use]
@@ -5,6 +6,9 @@ extern crate lazy_static;
 
 use std::env;
 use std::sync::atomic::{AtomicUsize, Ordering};
+
+mod ops;
+pub use ops::*;
 
 /// A helper trait to select a value from a same-typed tuple
 #[doc(hidden)]
@@ -136,7 +140,7 @@ impl Mutagen {
             3 => x <= y,
             4 => x >= y,
             5 => x == y,
-            6 => x != y, // != with PartialOrd
+            6 => x != y,
             _ => x > y,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
-
+/// Welcome to the mutagen crate. Your entry point will probably be cargo-mutagen, so install it
+/// right away.
 #[macro_use]
 extern crate lazy_static;
 
@@ -6,13 +7,18 @@ use std::env;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 /// A helper trait to select a value from a same-typed tuple
+#[doc(hidden)]
 pub trait Selector<T> {
     fn get(self, n: usize) -> T;
 }
 
 impl<T> Selector<T> for (T, T) {
     fn get(self, n: usize) -> T {
-        if n == 0 { self.1 } else { self.0 }
+        if n == 0 {
+            self.1
+        } else {
+            self.0
+        }
     }
 }
 
@@ -21,7 +27,7 @@ impl<T> Selector<T> for (T, T, T) {
         match n {
             0 => self.1,
             1 => self.2,
-            _ => self.0
+            _ => self.0,
         }
     }
 }
@@ -32,7 +38,7 @@ impl<T> Selector<T> for (T, T, T, T) {
             0 => self.1,
             1 => self.2,
             2 => self.3,
-            _ => self.0
+            _ => self.0,
         }
     }
 }
@@ -48,8 +54,9 @@ lazy_static! {
 ///
 /// This is used by the Mutagen crate to simplify the code it inserts.
 /// You should have no business using it manually.
+#[doc(hidden)]
 pub struct Mutagen {
-    x: AtomicUsize
+    x: AtomicUsize,
 }
 
 impl Mutagen {
@@ -65,24 +72,27 @@ impl Mutagen {
         self.get() == n
     }
 
+    pub fn diff(&self, n: usize) -> usize {
+        self.get().wrapping_sub(n)
+    }
+
     /// increment the mutation count
     pub fn next(&self) {
-        //TODO: clamp at maximum, return Option<usize>, impl Iterator?
         self.x.fetch_add(1, Ordering::SeqCst);
     }
 
     /// insert the original or an alternate value, e.g. `MU.select(&[2, 0], 42)`
     pub fn select<T, S: Selector<T>>(&self, selector: S, n: usize) -> T {
-        selector.get(self.get().wrapping_sub(n))
+        selector.get(self.diff(n))
     }
 
     /// use with if expressions, e.g. `if MU.t(..) { .. } else { .. }`
     pub fn t(&self, t: bool, n: usize) -> bool {
-        match self.get().wrapping_sub(n) {
+        match self.diff(n) {
             0 => true,
             1 => false,
             2 => !t,
-            _ => t
+            _ => t,
         }
     }
 
@@ -90,106 +100,58 @@ impl Mutagen {
     ///
     /// this never leads to infinite loops
     pub fn w(&self, t: bool, n: usize) -> bool {
-        if self.get() == n { false } else { t }
-    }
-
-    /// use instead of `&&`
-    ///
-    /// upholds the invariant that g() is not called unless f() == true
-    pub fn and<X, Y>(&self, f: X, g: Y, n: usize) -> bool
-        where X: FnOnce() -> bool, Y: FnOnce() -> bool {
-        match self.get().wrapping_sub(n) {
-            0 => false,
-            1 => true,
-            2 => f(),
-            3 => !f(),
-            4 => f() && !g(),
-            _ => f() && g()
-        }
-    }
-
-    /// use instead of `||`
-    ///
-    /// upholds the invariant that g() is not called unless f() == false
-    pub fn or<X, Y>(&self, f: X, g: Y, n: usize) -> bool
-        where X: FnOnce() -> bool, Y: FnOnce() -> bool {
-        match self.get().wrapping_sub(n) {
-            0 => false,
-            1 => true,
-            2 => f(),
-            3 => !f(),
-            4 => f() || !g(),
-            _ => f() || g()
+        if self.now(n) {
+            false
+        } else {
+            t
         }
     }
 
     /// use instead of `==`
-    pub fn eq<X, Y, T: PartialEq>(&self, x: X, y: Y, n: usize) -> bool
-    where X: FnOnce() -> T, Y: FnOnce() -> T {
-        match self.get().wrapping_sub(n) {
+    pub fn eq<R, T: PartialEq<R>>(&self, x: T, y: R, n: usize) -> bool {
+        match self.diff(n) {
             0 => true,
             1 => false,
-            2 => x() != y(),
-            _ => x() == y()
+            2 => x != y,
+            _ => x == y,
         }
     }
 
     /// use instead of `!=`
-    pub fn ne<X, Y, T: PartialEq>(&self, x: X, y: Y, n: usize) -> bool
-        where X: FnOnce() -> T, Y: FnOnce() -> T {
-        match self.get().wrapping_sub(n) {
+    pub fn ne<R, T: PartialEq<R>>(&self, x: T, y: R, n: usize) -> bool {
+        match self.diff(n) {
             0 => true,
             1 => false,
-            2 => x() == y(),
-            _ => x() != y()
+            2 => x == y,
+            _ => x != y,
         }
     }
 
     /// use instead of `>` (or, switching operand order `<`)
-    pub fn gt<X, Y, T: PartialOrd>(&self, x: X, y: Y, n: usize) -> bool
-        where X: FnOnce() -> T, Y: FnOnce() -> T {
-        match self.get().wrapping_sub(n) {
+    pub fn gt<R, T: PartialOrd<R>>(&self, x: T, y: R, n: usize) -> bool {
+        match self.diff(n) {
             0 => false,
             1 => true,
-            2 => x() < y(),
-            3 => x() <= y(),
-            4 => x() >= y(),
-            5 => {
-                let xv = x();
-                let yv = y();
-                xv <= yv && xv >= yv
-            }, // == with PartialOrd
-            6 => {
-                let xv = x();
-                let yv = y();
-
-                xv < yv || xv > yv
-            }, // != with PartialOrd
-            _ => x() > y()
+            2 => x < y,
+            3 => x <= y,
+            4 => x >= y,
+            5 => x == y,
+            6 => x != y, // != with PartialOrd
+            _ => x > y,
         }
     }
 
     /// use instead of `>=` (or, switching operand order `<=`)
-    pub fn ge<X, Y, T: PartialOrd>(&self, x: X, y: Y, n: usize) -> bool
-        where X: FnOnce() -> T, Y: FnOnce() -> T {
-        match self.get().wrapping_sub(n) {
+    pub fn ge<R, T: PartialOrd<R>>(&self, x: T, y: R, n: usize) -> bool {
+        match self.diff(n) {
             0 => false,
             1 => true,
-            2 => x() < y(),
-            3 => x() <= y(),
-            4 => x() > y(),
-            5 => {
-                let xv = x();
-                let yv = y();
-                xv <= yv && xv >= yv
-            }, // == with PartialOrd
-            6 => {
-                let xv = x();
-                let yv = y();
-
-                xv < yv || xv > yv
-            }, // != with PartialOrd
-            _ => x() >= y()
+            2 => x < y,
+            3 => x <= y,
+            4 => x > y,
+            5 => x == y,
+            6 => x != y,
+            _ => x >= y,
         }
     }
 }
@@ -204,6 +166,11 @@ pub fn get() -> usize {
 /// this simplifies operations like `if mutagen::MU.now(42) { .. }`
 pub fn now(n: usize) -> bool {
     MU.now(n)
+}
+
+/// get the unsigned wrapping difference between the current mutation count and the given count
+pub fn diff(n: usize) -> usize {
+    MU.diff(n)
 }
 
 /// increment the mutation count
@@ -228,49 +195,23 @@ pub fn w(t: bool, n: usize) -> bool {
     MU.w(t, n)
 }
 
-/// use instead of `&&`
-///
-/// upholds the invariant that g() is not called unless f() == true
-pub fn and<X, Y>(f: X, g: Y, n: usize) -> bool
-where
-    X: FnOnce() -> bool,
-    Y: FnOnce() -> bool,
-{
-    MU.and(f, g, n)
-}
-
-/// use instead of `||`
-///
-/// upholds the invariant that g() is not called unless f() == false
-pub fn or<X, Y>(f: X, g: Y, n: usize) -> bool
-where
-    X: FnOnce() -> bool,
-    Y: FnOnce() -> bool,
-{
-    MU.or(f, g, n)
-}
-
 /// use instead of `==`
-pub fn eq<X, Y, T: PartialEq>(x: X, y: Y, n: usize) -> bool
-    where X: FnOnce() -> T, Y: FnOnce() -> T {
+pub fn eq<R, T: PartialEq<R>>(x: T, y: R, n: usize) -> bool {
     MU.eq(x, y, n)
 }
 
 /// use instead of `!=`
-pub fn ne<X, Y, T: PartialEq>(x: X, y: Y, n: usize) -> bool
-    where X: FnOnce() -> T, Y: FnOnce() -> T {
+pub fn ne<R, T: PartialEq<R>>(x: T, y: R, n: usize) -> bool {
     MU.ne(x, y, n)
 }
 
 /// use instead of `>` (or, switching operand order `<`)
-pub fn gt<X, Y, T: PartialOrd>(x: X, y: Y, n: usize) -> bool
-    where X: FnOnce() -> T, Y: FnOnce() -> T {
+pub fn gt<R, T: PartialOrd<R>>(x: T, y: R, n: usize) -> bool {
     MU.gt(x, y, n)
 }
 
 /// use instead of `>=` (or, switching operand order `<=`)
-pub fn ge<X, Y, T: PartialOrd>(x: X, y: Y, n: usize) -> bool
-    where X: FnOnce() -> T, Y: FnOnce() -> T {
+pub fn ge<R, T: PartialOrd<R>>(x: T, y: R, n: usize) -> bool {
     MU.ge(x, y, n)
 }
 
@@ -280,45 +221,49 @@ mod tests {
 
     #[test]
     fn eq_mutation() {
-        let mu = Mutagen { x: AtomicUsize::new(0) };
+        let mu = Mutagen {
+            x: AtomicUsize::new(0),
+        };
 
         // Always true
-        assert_eq!(true, mu.eq(|| 1, || 0, 0));
+        assert_eq!(true, mu.eq(1, 0, 0));
 
         // Always false
         mu.next();
-        assert_eq!(false, mu.eq(|| 1, || 0, 0));
+        assert_eq!(false, mu.eq(1, 0, 0));
 
         // Checks inequality
         mu.next();
-        assert_eq!(true, mu.eq(|| 0, || 1, 0));
-        assert_eq!(false, mu.eq(|| 1, || 1, 0));
+        assert_eq!(true, mu.eq(0, 1, 0));
+        assert_eq!(false, mu.eq(1, 1, 0));
 
         // Checks equality
         mu.next();
-        assert_eq!(true, mu.eq(|| 0, || 0, 0));
-        assert_eq!(false, mu.eq(|| 1, || 0, 0));
+        assert_eq!(true, mu.eq(0, 0, 0));
+        assert_eq!(false, mu.eq(1, 0, 0));
     }
 
     #[test]
     fn ne_mutation() {
-        let mu = Mutagen { x: AtomicUsize::new(0) };
+        let mu = Mutagen {
+            x: AtomicUsize::new(0),
+        };
 
         // Always true
-        assert_eq!(true, mu.ne(|| 1, || 0, 0));
+        assert_eq!(true, mu.ne(1, 0, 0));
 
         // Always false
         mu.next();
-        assert_eq!(false, mu.ne(|| 1, || 0, 0));
+        assert_eq!(false, mu.ne(1, 0, 0));
 
         // Checks equality
         mu.next();
-        assert_eq!(false, mu.ne(|| 0, || 1, 0));
-        assert_eq!(true, mu.ne(|| 1, || 1, 0));
+        assert_eq!(false, mu.ne(0, 1, 0));
+        assert_eq!(true, mu.ne(1, 1, 0));
 
         // Checks inequality
         mu.next();
-        assert_eq!(false, mu.ne(|| 0, || 0, 0));
-        assert_eq!(true, mu.ne(|| 1, || 0, 0));
+        assert_eq!(false, mu.ne(0, 0, 0));
+        assert_eq!(true, mu.ne(1, 0, 0));
     }
 }


### PR DESCRIPTION
This fixes #34 and removes unneeded closures for all operations. With the last commit, we also get a first step towards #21 and #12, among others. 

I also ran rustfmt over the plugin.