### PR TITLE
 Avoid mutate expressions on match Range patterns 

### DIFF
--- a/plugin/src/lib.rs
+++ b/plugin/src/lib.rs
@@ -700,6 +700,24 @@ impl<'a, 'cx> Folder for MutatorPlugin<'a, 'cx> {
         }) //TODO: more expr mutations
     }
 
+
+    fn fold_pat(&mut self, pat: P<Pat>) -> P<Pat> {
+        pat.and_then(|pattern|
+            match pattern {
+                Pat {
+                    id,
+                    node: PatKind::Range(e1, e2, e3),
+                    span,
+                } => {
+                    // Avoid recursion on range patterns, it only literals are allowed, and mutations
+                    // would potentially convert them into expressions
+                    P(Pat {id, node: PatKind::Range(e1, e2, e3), span})
+                },
+                p => fold::noop_fold_pat(P(p), self),
+            }
+        )
+    }
+
     fn fold_mac(&mut self, mac: Mac) -> Mac {
         mac
     }

--- a/plugin/tests/compile-fail/patterns.rs
+++ b/plugin/tests/compile-fail/patterns.rs
@@ -1,0 +1,22 @@
+#![feature(plugin)]
+#![plugin(mutagen_plugin)]
+#![feature(custom_attribute)]
+extern crate mutagen;
+
+#[mutate]
+//~^ ERROR arbitrary expressions
+fn matches() {
+    match 2 {
+        1...3 => (),    //~ ERROR [E0029]
+        _ => (),
+    };
+
+    match 'a' {
+        'a'...'z' => (),
+        _ => (),
+    };
+}
+
+fn main() {
+
+}

--- a/plugin/tests/run-pass/patterns.rs
+++ b/plugin/tests/run-pass/patterns.rs
@@ -4,10 +4,10 @@
 extern crate mutagen;
 
 #[mutate]
-//~^ ERROR arbitrary expressions
 fn matches() {
     match 2 {
-        1...3 => (),    //~ ERROR [E0029]
+        1...3 => (),
+        a if 3 > 4 => (),
         _ => (),
     };
 


### PR DESCRIPTION
Match may have distinct types of patterns. When they are numeric or char
ranges, they need to be literals, but not expressions. If we do that mutation, we get the following error:

```
error[E0029]: only char and numeric types are allowed in range patterns
```

Now, when we detect a `Pat` which is of `PatKind::Range`, we are **not**
recursively mutating expressions. Otherwise, we are mutating as we were
doing before.