### PR TITLE
Change coverage flags to use a per-fn [AtomicUsize;_ ]

### DIFF
--- a/runner/src/runner.rs
+++ b/runner/src/runner.rs
@@ -120,7 +120,6 @@ impl CoverageRunner {
                 let cmd_result = Command::new(&self.test_executable)
                     .args(&[&test_name])
                     .env("MUTAGEN_COVERAGE", "file:target/mutagen/coverage.txt")
-                    .env("MUTAGEN_MUTATION_AMOUNT", self.mutation_amount.to_string())
                     .output();
 
                 let cmd_successful = cmd_result

--- a/src/coverage.rs
+++ b/src/coverage.rs
@@ -2,41 +2,28 @@ use std::env;
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::ops::Range;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
-lazy_static! {
-    static ref COVERAGE_ALREADY_CHECKED: Vec<AtomicBool> = {
-        let max = env::var("MUTAGEN_MUTATION_AMOUNT").map(|s|s.parse().unwrap_or(0)).unwrap_or(0) + 1;
-        (0..max).map(|_| AtomicBool::new(false)).collect()
-    };
-}
-
-pub fn report_coverage(mutations: Range<usize>) {
-    let mutagen_coverage = env::var_os("MUTAGEN_COVERAGE");
-    if mutagen_coverage.is_none() {
-        return
+pub fn report_coverage(mutations: Range<usize>, flag: &AtomicUsize, mask: usize) {
+    if flag.fetch_or(mask, Ordering::SeqCst) & mask != 0 {
+        return // already logged
     }
+    if let Some(_) = env::var_os("MUTAGEN_COVERAGE") {
+        // TODO: Should parse the env var and check the reporting strategy: file, socket, ...
+        let muts: Vec<String> = mutations
+            .map(|n| format!("{}", n))
+            .collect();
 
-    if let Some(ab) = COVERAGE_ALREADY_CHECKED.get(mutations.start) {
-        if ab.compare_and_swap(false, true, Ordering::SeqCst) == false {
-            if let Some(_) = mutagen_coverage {
-                // TODO: Should parse the env var and check the reporting strategy: file, socket, ...
-                let muts: Vec<String> = mutations
-                    .map(|n| format!("{}", n))
-                    .collect();
+        let _res = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .truncate(false)
+            .open("target/mutagen/coverage.txt")
+            .and_then(|mut f| {
+                let mut joined = muts.join(",");
+                joined.push_str(",");
 
-                let _res = OpenOptions::new()
-                    .create(true)
-                    .append(true)
-                    .truncate(false)
-                    .open("target/mutagen/coverage.txt")
-                    .and_then(|mut f| {
-                        let mut joined = muts.join(",");
-                        joined.push_str(",");
-
-                        f.write_all(joined.as_bytes())
-                    });
-            }
-        }
+                f.write_all(joined.as_bytes())
+            });
     }
 }


### PR DESCRIPTION
This is a thing I wanted to do for some time, and I finally got around to doing it :slightly_smiling_face:. The solution here is to first create a `static <genkey#N>: [AtomicUsize; 0]`, then do all the mutations, come back and patch up the length.