### PR TITLE
Add mutation for iterators to skip elements

### DIFF
--- a/plugin/src/lib.rs
+++ b/plugin/src/lib.rs
@@ -477,6 +477,37 @@ impl<'a, 'cx> Folder for MutatorPlugin<'a, 'cx> {
             }
             Expr {
                 id,
+                node: ExprKind::ForLoop(pat, expr, block, ident),
+                span,
+                attrs,
+            } => {
+                let (n, current, sym, flag, mask) = self.add_mutations(
+                    expr.span,
+                    &[
+                        "empty iterator",
+                        "skip first element",
+                        "skip last element",
+                        "skip first and last element",
+                    ],
+                );
+                let pat = self.fold_pat(pat);
+                let expr = self.fold_expr(expr);
+                let block = fold::noop_fold_block(block, self);
+
+                let expr = quote_expr!(self.cx(), {
+                    ::mutagen::report_coverage($n..$current, &$sym[$flag], $mask);
+                    ::mutagen::forloop($expr, $n)
+                });
+
+                P(Expr {
+                    id,
+                    node: ExprKind::ForLoop(pat, expr, block, ident),
+                    span,
+                    attrs,
+                })
+            }
+            Expr {
+                id,
                 node: ExprKind::Unary(UnOp::Neg, exp),
                 span,
                 attrs,

--- a/plugin/tests/run-pass/for_loops.rs
+++ b/plugin/tests/run-pass/for_loops.rs
@@ -1,0 +1,25 @@
+#![feature(plugin)]
+#![plugin(mutagen_plugin)]
+#![feature(custom_attribute)]
+
+extern crate mutagen;
+
+#[mutate]
+fn main() {
+    // Mutate range
+    for i in 0..5 {
+
+    }
+
+    // Mutate vector
+    let v = vec![0, 1, 2, 3];
+    for i in v.iter() {
+
+    }
+
+    // Slice with mutable iterator
+    let mut slice = &mut [1, 2, 3];
+    for element in slice.iter_mut() {
+
+    }
+}

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -1,0 +1,74 @@
+
+/// NoopIterator is an iterator that will return `None`
+pub struct NoopIterator<I: Iterator> {
+    pub inner: I,
+}
+
+impl<I: Iterator> Iterator for NoopIterator<I> {
+    type Item = I::Item;
+
+    fn next(&mut self) -> Option<I::Item> {
+        None
+    }
+}
+
+pub struct SkipLast<I: Iterator> {
+    /// Contains the inner iterator
+    pub inner: I,
+    /// Stashed contains the following element to be returned on the iterator. We need this value,
+    /// as we need to advance the inner iterator one step ahead, to be able to check when the
+    /// inner iterator ends. If this is the case, we need to ignore the stashed value.
+    stashed: Option<I::Item>,
+}
+
+impl<I: Iterator> SkipLast<I> {
+    pub fn new(mut inner: I) -> Self {
+        let stashed = inner.next();
+
+        SkipLast {
+            inner,
+            stashed,
+        }
+    }
+}
+
+impl<I: Iterator> Iterator for SkipLast<I> {
+    type Item = I::Item;
+
+    fn next(&mut self) -> Option<I::Item> {
+        let current = self.stashed.take();
+        let next = self.inner.next();
+
+        if next.is_none() {
+            None
+        } else {
+            self.stashed = next;
+
+            current
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_skip_last_iterator() {
+        let examples = vec![
+            (vec![1, 2, 3, 4, 5], vec![1, 2, 3, 4]),
+            (vec![1, 2, 3, 4], vec![1, 2, 3]),
+            (vec![1, 2, 3], vec![1, 2]),
+            (vec![1, 2], vec![1]),
+            (vec![1], Vec::<i32>::new()),
+            (vec![], Vec::<i32>::new()),
+        ];
+
+        for e in examples {
+            let skip_bound = SkipLast::new(e.0.iter());
+            let skipped: Vec<i32> = skip_bound.cloned().collect();
+
+            assert_eq!(e.1, skipped);
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 mod ops;
 pub use ops::*;
+mod iterators;
 
 mod coverage;
 pub use coverage::report_coverage;
@@ -161,6 +162,16 @@ impl Mutagen {
             _ => x >= y,
         }
     }
+
+    pub fn forloop<'a, I: Iterator + 'a>(&self, i: I, n: usize) -> Box<Iterator<Item=I::Item> + 'a> {
+        match self.diff(n) {
+            0 => Box::new(iterators::NoopIterator{inner: i}),
+            1 => Box::new(i.skip(1)),
+            2 => Box::new(iterators::SkipLast::new(i)),
+            3 => Box::new(iterators::SkipLast::new(i.skip(1))),
+            _ => Box::new(i),
+        }
+    }
 }
 
 /// get the current mutation count
@@ -220,6 +231,10 @@ pub fn gt<R, T: PartialOrd<R>>(x: T, y: R, n: usize) -> bool {
 /// use instead of `>=` (or, switching operand order `<=`)
 pub fn ge<R, T: PartialOrd<R>>(x: T, y: R, n: usize) -> bool {
     MU.ge(x, y, n)
+}
+
+pub fn forloop<'a, I: Iterator + 'a>(i: I, n: usize) -> Box<Iterator<Item=I::Item > + 'a> {
+    MU.forloop(i, n)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Added a mutation for for-loops to mutate the iterator to the following
cases:

- Empty iterator (no elements will be yielded)
- Skip first element
- Skip last element
- Skip first and last element
