### PR TITLE
Fix a couple of issues on runner

### DIFF
--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -142,7 +142,7 @@ fn run() -> Result<()> {
     for test_executable in tests_executable {
         println!("test executable at {:?}", test_executable);
         let runner: Box<Runner> = if with_coverage {
-            Box::new(CoverageRunner::new(test_executable.clone(), list.len()))
+            Box::new(CoverageRunner::new(test_executable.clone()))
         } else {
             Box::new(FullSuiteRunner::new(test_executable.clone()))
         };

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -90,7 +90,8 @@ fn compile_tests() -> Result<Vec<PathBuf>> {
     let mut tests: Vec<PathBuf> = Vec::new();
     let compile_out = Command::new("cargo")
         .args(&["test", "--no-run", "--message-format=json"])
-        .args(std::env::args_os())
+        // We need to skip first two arguments (path to mutagen binary and "mutagen" string)
+        .args(std::env::args_os().skip(2))
         .stderr(Stdio::inherit())
         .output()?;
 

--- a/runner/src/runner.rs
+++ b/runner/src/runner.rs
@@ -52,16 +52,14 @@ impl Runner for FullSuiteRunner {
 /// by test), which may be non-performant if almost all the tests are mutated
 pub struct CoverageRunner {
     test_executable: PathBuf,
-    mutation_amount: usize,
     tests_with_mutations: RefCell<Option<Rc<TestsByMutation>>>,
 }
 
 impl CoverageRunner {
     /// creates a runner from the test executable path
-    pub fn new(test_executable: PathBuf, mutation_amount: usize) -> CoverageRunner {
+    pub fn new(test_executable: PathBuf) -> CoverageRunner {
         CoverageRunner {
             test_executable,
-            mutation_amount,
             tests_with_mutations: RefCell::new(None),
         }
     }


### PR DESCRIPTION
This solves two little issues on the runner:

- Remove some remaining code that was not removed when the new coverage
method was introduced
- Skip first 2 arguments that are forwarded to tests: We need to skip this 2 arguments, as they are meaningless to cargo test and it's provoking that tests are not being compiled. This happens
because cargo test is not recognizing that flags.