### PR TITLE
Check runner on example project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,9 @@ script:
   - pushd plugin
   - cargo test
   - popd
+  - pushd runner
+  - cargo install -f
+  - popd
+  - pushd examples/example_project
+  - cargo mutagen
+  - cargo mutagen -- --coverage


### PR DESCRIPTION
Trying to run the plugin on the example project, with and without
coverage.
This should allow to avoid some regressions and make sure that we don't
break the runner.
