### PR TITLE
Fix methods on impl blocks

### DIFF
--- a/plugin/tests/compile-fail/impl-method.rs
+++ b/plugin/tests/compile-fail/impl-method.rs
@@ -1,0 +1,16 @@
+#![feature(plugin)]
+#![plugin(mutagen_plugin)]
+#![feature(custom_attribute)]
+extern crate mutagen;
+
+fn main() {}
+
+struct Test {}
+
+impl Test {
+    #[mutate]
+    //~^ cannot find value `__COVERAGE1` in this scope [E0425]
+    pub fn method(&self) -> i32 {
+        5
+    }
+}

--- a/plugin/tests/run-pass/impl-method.rs
+++ b/plugin/tests/run-pass/impl-method.rs
@@ -9,8 +9,16 @@ struct Test {}
 
 impl Test {
     #[mutate]
-    //~^ cannot find value `__COVERAGE1` in this scope [E0425]
     pub fn method(&self) -> i32 {
+        5
+    }
+
+    #[mutate]
+    pub fn nested(&self) -> i32 {
+        let a = {
+            43
+        };
+
         5
     }
 }


### PR DESCRIPTION
Methods on impl blocks were not calling the `fold_first_block` method,
which means that all the per-method mutations were not applied and that
coverage local static var was not added on the scope, leading to a
compilation error.