### PR TITLE
fix #77

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -87,7 +87,7 @@ fn write_opassign_arm(out: &mut Write,
                 );
                 quote_expr!(p.cx(), {{
                     ::mutagen::report_coverage($n..$current, &$sym[$flag], $mask);
-                    ::mutagen::{0}{2}Assign::{1}_assign($left, $right, $n)
+                    ::mutagen::{0}{2}Assign::{1}_assign(&mut $left, $right, $n)
                 }})
             }}", o_trait, o_fn, mut_trait, o_sym, mut_sym)
 }

--- a/build.rs
+++ b/build.rs
@@ -329,7 +329,7 @@ pub fn fold_binop(p: &mut MutatorPlugin, id: NodeId, op: BinOp, left: P<Expr>, r
         attrs: ThinVec<Attribute>) -> P<Expr> {{
     match op.node {{")?;
     for names in BINOP_PAIRS.iter() {
-        //
+        //                 BufWriter Add       add       Sub       +         -
         write_opassign_arm(&mut out, names[0], names[1], names[2], names[4], names[5])?;
         write_opassign_arm(&mut out, names[2], names[3], names[0], names[5], names[4])?;
     }

--- a/plugin/src/lib.rs
+++ b/plugin/src/lib.rs
@@ -764,8 +764,8 @@ fn destructure_bindings<'t>(
     result: &mut Vec<(Symbol, ArgTy<'t>)>,
 ) {
     match pat.node {
-        PatKind::Ident(mode, sp_ident, ref opt_pat) => {
-            result.push((sp_ident.node.name, ArgTy(mode, ty, pos, occ.clone())));
+        PatKind::Ident(mode, ident, ref opt_pat) => {
+            result.push((ident.name, ArgTy(mode, ty, pos, occ.clone())));
             if let Some(ref pat) = *opt_pat {
                 destructure_bindings(pat, ty, occ, pos, result);
             }
@@ -832,7 +832,7 @@ fn destructure_bindings<'t>(
 fn unbox(ty: &Ty) -> Option<&Ty> {
     if let TyKind::Path(_, ref path) = ty.node {
         if let Some(box_seg) = path.segments.iter().last() {
-            if box_seg.identifier.name != "Box" {
+            if box_seg.ident.name != "Box" {
                 return None;
             }
             if let Some(ref params) = box_seg.parameters {
@@ -972,7 +972,7 @@ fn is_whitelisted_path(path: &Path) -> bool {
 }
 
 fn path_segment_hash<H: Hasher>(seg: &PathSegment, pos: usize, h: &mut H) {
-    seg.identifier.hash(h);
+    seg.ident.hash(h);
     if let Some(ref params) = seg.parameters {
         match **params {
             PathParameters::AngleBracketed(ref data) => {
@@ -999,7 +999,7 @@ fn path_segment_hash<H: Hasher>(seg: &PathSegment, pos: usize, h: &mut H) {
 }
 
 fn path_segment_equal(a: &PathSegment, b: &PathSegment, inout: bool) -> bool {
-    a.identifier == b.identifier && optd(&a.parameters, &b.parameters, |a, b| match (&**a, &**b) {
+    a.ident == b.ident && optd(&a.parameters, &b.parameters, |a, b| match (&**a, &**b) {
         (&PathParameters::AngleBracketed(ref adata), &PathParameters::AngleBracketed(ref bdata)) => {
             (if adata.lifetimes.is_empty() {
                 inout && bdata.lifetimes.is_empty()
@@ -1195,7 +1195,7 @@ fn is_ty_default(ty: &Ty, self_ty: Option<&Ty>) -> bool {
                         .path
                         .segments
                         .last()
-                        .map_or(false, |s| s.identifier.name == "Default")
+                        .map_or(false, |s| s.ident.name == "Default")
                 } else {
                     false
                 }
@@ -1253,7 +1253,7 @@ fn match_path(path: &Path, pat: &[&str]) -> bool {
         .iter()
         .rev()
         .zip(pat.iter().rev())
-        .all(|(a, b)| &a.identifier.name == b)
+        .all(|(a, b)| &a.ident.name == b)
 }
 
 fn get_lit(expr: &Expr) -> Option<u128> {

--- a/plugin/src/lib.rs
+++ b/plugin/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(plugin_registrar, quote, rustc_private, custom_attribute, i128_type)]
+#![feature(plugin_registrar, quote, rustc_private, custom_attribute)]
 
 extern crate rustc_plugin;
 extern crate syntax;

--- a/plugin/tests/run-pass/issue-77.rs
+++ b/plugin/tests/run-pass/issue-77.rs
@@ -1,0 +1,12 @@
+#![feature(plugin)]
+#![plugin(mutagen_plugin)]
+#![feature(custom_attribute)]
+
+extern crate mutagen;
+
+#[mutate]
+fn main() {
+    let mut count = 0;
+    count += 1;
+    println!("{}", count * 2);
+}


### PR DESCRIPTION
This adds a missing `&mut` to the `XYAssign::x_assign` calls. Also removes a no longer needed feature gate.

r? @gnieto since you found the bug.