### PR TITLE
disable shift mutation

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -96,7 +96,7 @@ fn write_opassign_arm(out: &mut Write,
 static BINOP_PAIRS: &[[&str; 6]] = &[
     ["Add", "add", "Sub", "sub", "+", "-"],
     ["Mul", "mul", "Div", "div", "*", "/"],
-    ["Shl", "shl", "Shr", "shr", "<<", ">>"],
+//    ["Shl", "shl", "Shr", "shr", "<<", ">>"],
     ["BitAnd", "bitand", "BitOr", "bitor", "&", "|"],
 //    ["BitXor", "bitxor", "BitOr", "bitor", "^"], TODO: allow multi-mutations
 //    ["BitAnd", "bitand", "BitXor", "bitxor"],


### PR DESCRIPTION
As long as we haven't fixed the problem with Shl/Shr forwarding, let's disable mutating bit shifts for now.