### PR TITLE
Improve runner output

### DIFF
--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["testing"]
 [dependencies]
 json = "0.11.12"
 failure = "0.1.1"
+colored = "1.6"
 
 [badges]
 travis-ci = { repository = "llogiq/mutagen", branch = "master" }

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -11,7 +11,6 @@ keywords = ["testing"]
 [dependencies]
 json = "0.11.12"
 failure = "0.1.1"
-colored = "1.6"
 
 [badges]
 travis-ci = { repository = "llogiq/mutagen", branch = "master" }

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 extern crate failure;
 extern crate json;
+extern crate colored;
 
 mod runner;
 
@@ -10,6 +11,7 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::str::from_utf8;
 use runner::{CoverageRunner, FullSuiteRunner, Runner};
+use colored::Colorize;
 
 static TARGET_MUTAGEN: &'static str = "target/mutagen";
 static MUTATIONS_LIST: &'static str = "mutations.txt";
@@ -18,10 +20,9 @@ type Result<T> = std::result::Result<T, failure::Error>;
 
 fn run_mutations(runner: Box<Runner>, list: &[String]) {
     let max_mutation = list.len();
+    let mut failures = 0usize;
 
-    let mut failures = Vec::new();
-
-    println!("Running {} mutations", max_mutation);
+    println!("Running {} mutations\n", max_mutation);
     for i in 0..max_mutation {
         // Mutation count starts from 1 (0 is not mutations)
         let mutation_count = i + 1;
@@ -30,39 +31,24 @@ fn run_mutations(runner: Box<Runner>, list: &[String]) {
 
         let result = runner.run(mutation_count);
 
-        if let Ok(stdout) = result {
+        let status = if let Ok(_) = result {
             // A succeeding test suite is actually a failure for us.
             // At least on test should have failed
-            failures.push((&list[i], mutation_count, stdout));
-            println!(" ... FAILED");
+            failures += 1;
+
+            "FAILED".bold().red()
         } else {
-            println!(" ... ok");
-        }
-    }
+            "ok".green()
+        };
 
-    if !failures.is_empty() {
-        println!("\nFailures:\n");
-
-        for &(ref mutation, ref m_count, ref failure) in &failures {
-            println!("---- {} ({}) stdout ----", mutation, m_count);
-            for line in failure.split("\n") {
-                println!("  {}", line);
-            }
-            println!("");
-        }
-
-        println!("\nFailures:\n");
-
-        for &(mutation, m_count, _) in &failures {
-            println!("\t{} ({})", mutation, m_count);
-        }
+        println!(" ... {}", status);
     }
 
     println!(
-        "\nMutation results: {}. {} passed; {} failed",
-        if failures.is_empty() { "ok" } else { "FAILED" },
-        list.len() - failures.len(),
-        failures.len()
+        "\nMutation results: {}. {} passed; {} failed\n",
+        if failures == 0 { "ok".green() } else { "FAILED".bold().red() },
+        list.len() - failures,
+        failures
     );
 }
 

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -1,7 +1,6 @@
 #[macro_use]
 extern crate failure;
 extern crate json;
-extern crate colored;
 
 mod runner;
 
@@ -11,7 +10,6 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::str::from_utf8;
 use runner::{CoverageRunner, FullSuiteRunner, Runner};
-use colored::Colorize;
 
 static TARGET_MUTAGEN: &'static str = "target/mutagen";
 static MUTATIONS_LIST: &'static str = "mutations.txt";
@@ -36,9 +34,9 @@ fn run_mutations(runner: Box<Runner>, list: &[String]) {
             // At least on test should have failed
             failures += 1;
 
-            "FAILED".bold().red()
+            "FAILED"
         } else {
-            "ok".green()
+            "ok"
         };
 
         println!(" ... {}", status);
@@ -46,7 +44,7 @@ fn run_mutations(runner: Box<Runner>, list: &[String]) {
 
     println!(
         "\nMutation results: {}. {} passed; {} failed\n",
-        if failures == 0 { "ok".green() } else { "FAILED".bold().red() },
+        if failures == 0 { "ok" } else { "FAILED" },
         list.len() - failures,
         failures
     );

--- a/runner/src/runner.rs
+++ b/runner/src/runner.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 pub trait Runner {
     /// run executes the testsuite with the given mutation count and returns the output
     /// if all tests has passed
-    fn run(&self, mutation_count: usize) -> Result<String, String>;
+    fn run(&self, mutation_count: usize) -> Result<(), ()>;
 }
 
 /// Full suite runner executes all the test at once, given the path of the executable
@@ -29,18 +29,17 @@ impl FullSuiteRunner {
 }
 
 impl Runner for FullSuiteRunner {
-    fn run(&self, mutation_count: usize) -> Result<String, String> {
+    fn run(&self, mutation_count: usize) -> Result<(), ()> {
         let output = Command::new(&self.test_executable)
             // 0 is actually no mutations so we need i + 1 here
             .env("MUTATION_COUNT", mutation_count.to_string())
             .output()
             .expect("failed to execute process");
 
-        let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
         if output.status.success() {
-            Ok(stdout)
+            Ok(())
         } else {
-            Err(stdout)
+            Err(())
         }
     }
 }
@@ -169,7 +168,7 @@ impl CoverageRunner {
 }
 
 impl Runner for CoverageRunner {
-    fn run(&self, mutation_count: usize) -> Result<String, String> {
+    fn run(&self, mutation_count: usize) -> Result<(), ()> {
         let test_by_mutation = self.tests_with_mutations();
 
         let out: (String, bool) = test_by_mutation
@@ -195,9 +194,9 @@ impl Runner for CoverageRunner {
             .unwrap_or((String::new(), true));
 
         if out.1 == true {
-            Ok(out.0)
+            Ok(())
         } else {
-            Err(out.0)
+            Err(())
         }
     }
 }


### PR DESCRIPTION
Improve a little bit mutagen's runner:

- Added colors for better visibility.
- Remove tests output when tests are ok; as we count non-failing tests
  as failure, the output was always the same: All tests green.
- Avoid saving the output of the test commands.