### PR TITLE
mutate ref muts by cloning

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -154,17 +154,20 @@ use std::sync::atomic::AtomicUsize;
     }
     writeln!(out, "
 pub trait MayClone<T> {{
-    fn may_clone(&self) -> bool;
+    fn may_clone(&self, mutation_count: usize, coverage: &AtomicUsize, mask: usize) -> bool;
     fn clone(&self) -> Self;
 }}
 
 impl<T> MayClone<T> for T {{
-    default fn may_clone(&self) -> bool {{ false }}
+    default fn may_clone(&self, _mc: usize, _cov: &AtomicUsize, _mask: usize) -> bool {{ false }}
     default fn clone(&self) -> Self {{ unimplemented!() }}
 }}
 
 impl<T: Clone> MayClone<T> for T {{
-    fn may_clone(&self) -> bool {{ true }}
+    fn may_clone(&self, mutation_count: usize, coverage: &AtomicUsize, mask: usize) -> bool {{
+        super::report_coverage(mutation_count..(mutation_count + 1), coverage, mask);
+        true
+    }}
     fn clone(&self) -> Self {{ self.clone() }}
 }}")?;
     out.flush()

--- a/plugin/tests/run-pass/clones.rs
+++ b/plugin/tests/run-pass/clones.rs
@@ -10,8 +10,8 @@ fn clones(ref mut a: &mut String, b: &mut String) {
 }
 
 fn main() {
-    let x = String::from("Hi");
-    let y = String::from("there");
+    let mut x = String::from("Hi");
+    let mut y = String::from("there");
 
     clones(&mut x, &mut y);
     println!("{} {}", x, y);

--- a/plugin/tests/run-pass/clones.rs
+++ b/plugin/tests/run-pass/clones.rs
@@ -1,0 +1,18 @@
+#![feature(plugin)]
+#![plugin(mutagen_plugin)]
+#![feature(custom_attribute)]
+extern crate mutagen;
+
+#[mutate]
+fn clones(ref mut a: &mut String, b: &mut String) {
+    a.push('a');
+    b.push('!');
+}
+
+fn main() {
+    let x = String::from("Hi");
+    let y = String::from("there");
+
+    clones(&mut x, &mut y);
+    println!("{} {}", x, y);
+}


### PR DESCRIPTION
This is one opportunistic mutation that was missing so far. It also moves coverage reporting into the trait impls so we only get reports for effective opportunistic mutations.

However, I run into the same problem as elsewhere when trying to report coverage in `fold_first_block`. Strange.