### PR TITLE
Fix mutation for interchangeables.

### DIFF
--- a/plugin/src/lib.rs
+++ b/plugin/src/lib.rs
@@ -678,13 +678,15 @@ fn fold_first_block(block: P<Block>, p: &mut MutatorPlugin) -> P<Block> {
                     let value_ident = value.to_ident();
                     let (n, current) = m.add_mutations(
                         block.span,
-                        &[&format!("exchange {} with {}", key.as_str(), value_ident)],
+                        &[&format!("exchange {} with {}", key_ident, value_ident)],
                     );
                     pre_stmts.push(
                         quote_stmt!(m.cx,
-                        if ::mutagen::now($n) {
-                            let ($key_ident, $value_ident) = ($value_ident, $key_ident);
-                         }).unwrap(),
+                        let ($key_ident, $value_ident) = if ::mutagen::now($n) {
+                            ($value_ident, $key_ident)
+                        } else {
+                            ($key_ident, $value_ident)
+                        };).unwrap(),
                     );
                 }
             }


### PR DESCRIPTION
Previously this was producing mutations like this, where the new variables go out of scope immediately and therefore have no effect.

```rust
if ::mutagen::now($n) {
    let (a, b) = (b, a);
}
```

Now it produces this, which I think is a nice example of variable shadowing being useful:
```rust
let (a, b) = if ::mutagen::now($n) {
    (b, a)
} else {
    (a, b)
};
```