### PR TITLE
Failing test for MayClone

### DIFF
--- a/plugin/tests/compile-fail/may-clone-reserved.rs
+++ b/plugin/tests/compile-fail/may-clone-reserved.rs
@@ -1,0 +1,17 @@
+#![feature(plugin)]
+#![plugin(mutagen_plugin)]
+#![feature(custom_attribute)]
+
+extern crate mutagen;
+
+fn main() {}
+
+struct SomeStruct{}
+
+impl SomeStruct {
+    #[mutate]
+    //~^ expected unit struct/variant or constant, found local variable `self` [E0424]
+    pub fn mutate_self(&mut self) {
+
+    }
+}


### PR DESCRIPTION
A method of a struct which recives `&mut self` gets an error when
mutated.

This is because the `MayClone` mutation as the code generated is:

```rust
            let self = if ::mutagen::MayClone::may_clone(self) {
                _self_clone =
                    ::mutagen::MayClone::clone(self, 2usize,
&__COVERAGE1[0usize], 2usize);
                &mut _self_clone
            } else {
                self
            };
```

This leads to initialize a variable with the name "self", which throws
this error: "expected unit struct/variant or constant, found local
variable `self` [E0424]"