### PR TITLE
Make self / Self interchange work

### DIFF
--- a/plugin/tests/integration.rs
+++ b/plugin/tests/integration.rs
@@ -61,6 +61,17 @@ fn interchange_struct(ComplexStruct{x: a, y: b}: ComplexStruct, ComplexStruct{x:
 
 }
 
+#[mutate]
+impl ComplexStruct {
+    fn interchange_self(self, other: Self) {
+
+    }
+
+    fn interchange_other_self(one: Self, other: Self) {
+
+    }
+}
+
 #[test]
 fn test_simple_interchange() {
     let checker = MutationsChecker::new("tests/integration.rs").unwrap();
@@ -103,6 +114,14 @@ fn test_complex_interchange() {
 
     assert!(checker.has("exchange a with c", "54"));
     assert!(checker.has("exchange b with d", "54"));
+}
+
+#[test]
+fn test_self_interchange() {
+    let checker = MutationsChecker::new("tests/integration.rs").unwrap();
+
+    assert!(checker.has("exchange self with other", "66"));
+    assert!(checker.has("exchange one with other", "70"));
 }
 
 #[test]


### PR DESCRIPTION
This fixes #103 

This makes both `Hash` and `PartialEq` implementations treat `self` and `_: Self` as equal, including putting them in the lifetime whitelist, because even if `Self` contains a lifetime, it's generally fixed and thus the same for all arguments.

While testing, I also noticed that putting `#[mutate]` on `impl` blocks didn't work, so I fixed that, too, while I was at it.