### PR TITLE
Fix issue with references and type-inference

### DIFF
--- a/plugin/tests/run-pass/issue-127.rs
+++ b/plugin/tests/run-pass/issue-127.rs
@@ -1,0 +1,25 @@
+#![feature(plugin)]
+#![plugin(mutagen_plugin)]
+#![feature(custom_attribute)]
+
+extern crate mutagen;
+
+#[mutate]
+fn something() -> bool {
+    let n = "test".as_bytes();
+    *n == *b"test"
+}
+
+#[mutate]
+fn owned_eq() -> Option<String> {
+    let x = "Hello".to_string();
+    if x == "Hello" {
+        Some(x)
+    } else {
+        None
+    }
+}
+
+fn main() {
+    something();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ impl Mutagen {
     }
 
     /// use instead of `==`
-    pub fn eq<R, T: PartialEq<R>>(&self, x: &T, y: &R, n: usize) -> bool {
+    pub fn eq<R, T: PartialEq<R>>(&self, x: T, y: R, n: usize) -> bool {
         match self.diff(n) {
             0 => true,
             1 => false,
@@ -103,7 +103,7 @@ impl Mutagen {
     }
 
     /// use instead of `!=`
-    pub fn ne<R, T: PartialEq<R>>(&self, x: &T, y: &R, n: usize) -> bool {
+    pub fn ne<R, T: PartialEq<R>>(&self, x: T, y: R, n: usize) -> bool {
         match self.diff(n) {
             0 => true,
             1 => false,
@@ -190,13 +190,13 @@ pub fn w(t: bool, n: usize, flag: &AtomicUsize, mask: usize) -> bool {
 }
 
 /// use instead of `==`
-pub fn eq<R, T: PartialEq<R>>(x: &T, y: &R, n: usize, flag: &AtomicUsize, mask: usize) -> bool {
+pub fn eq<R, T: PartialEq<R>>(x: T, y: R, n: usize, flag: &AtomicUsize, mask: usize) -> bool {
     report_coverage(n..(n + 3), flag, mask);
     MU.eq(x, y, n)
 }
 
 /// use instead of `!=`
-pub fn ne<R, T: PartialEq<R>>(x: &T, y: &R, n: usize, flag: &AtomicUsize, mask: usize) -> bool {
+pub fn ne<R, T: PartialEq<R>>(x: T, y: R, n: usize, flag: &AtomicUsize, mask: usize) -> bool {
     report_coverage(n..(n + 3), flag, mask);
     MU.ne(x, y, n)
 }
@@ -268,5 +268,15 @@ mod tests {
         mu.next();
         assert_eq!(false, mu.ne(&0, &0, 0));
         assert_eq!(true, mu.ne(&1, &0, 0));
+    }
+
+    #[test]
+    fn eq_with_references() {
+        let n = "test".as_bytes();
+        let mu = Mutagen {
+            x: AtomicUsize::new(0),
+        };
+
+        assert_eq!(true, mu.eq(&*n, &*b"test", 0));
     }
 }


### PR DESCRIPTION
Tentatively fixes https://github.com/llogiq/mutagen/issues/127

When we call to `::mutagen::eq`, we are borrowing the left and right
  values (so, we are `::mutagen::eq(&x, &y, ...)`. The previous
signature was also forcing a borrow `::mutagen::eq(x: &T, y: &R)`, which
provoked some type-inference issues as reported on:
https://github.com/llogiq/mutagen/issues/127.