### PR TITLE
add options to pass features in mutagen runner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,7 @@ script:
 
   # run executable cargo-mutagen on test project
   - pushd examples/simple
-  - cargo run --bin cargo-mutagen --package cargo-mutagen
+  - cargo run --package cargo-mutagen
+  - popd
+  - pushd examples/feature-gated
+  - cargo run --package cargo-mutagen -- --features with_mutagen

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "mutagen-transform",
     "mutagen-selftest",
     "examples/simple",
+    "examples/feature-gated",
     "examples/with-integration-tests-v1",
     "examples/with-integration-tests-v2",
 ]

--- a/examples/feature-gated/Cargo.toml
+++ b/examples/feature-gated/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "feature-gated"
+version = "0.2.0"
+authors = ["Samuel Pilz <samuel.pilz@posteo.net>"]
+edition = "2018"
+
+[dev-dependencies]
+mutagen = {path = "../../mutagen"}
+
+[lib]
+doctest = false
+
+[features]
+with_mutagen = []
+

--- a/examples/feature-gated/src/lib.rs
+++ b/examples/feature-gated/src/lib.rs
@@ -1,0 +1,14 @@
+#[cfg_attr(all(test, feature = "with_mutagen"), ::mutagen::mutate)]
+pub fn foo() -> i32 {
+    1 + 2
+}
+
+#[cfg(test)]
+mod tests {
+    use super::foo;
+
+    #[test]
+    fn test_foo() {
+        assert_eq!(foo(), 3);
+    }
+}

--- a/mutagen-runner/Cargo.toml
+++ b/mutagen-runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-mutagen"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Andre Bogus <bogusandre@gmail.com>", "Samuel Pilz <samuel.pilz@posteo.net>"]
 edition = "2018"
 
@@ -12,6 +12,7 @@ serde_json = "1.0"
 mutagen-core = { path = "../mutagen-core"}
 console = "0.9.1"
 humantime = "2.0.0"
+structopt = "0.3"
 
 [badges]
 travis-ci = { repository = "llogiq/mutagen", branch = "master" }


### PR DESCRIPTION
Fixes first part of #154.

This adds flags `--features` and `--all-features` to the runner in the same way cargo handles them. 