### PR TITLE
fix cargo-mutagen usage as cargo subcommand

### DIFF
--- a/mutagen-runner/src/main.rs
+++ b/mutagen-runner/src/main.rs
@@ -1,5 +1,6 @@
 use failure::{bail, Fallible};
 use std::collections::HashMap;
+use std::env;
 use std::fs::File;
 use std::io::BufWriter;
 use std::path::PathBuf;
@@ -36,7 +37,13 @@ struct Options {
 fn run() -> Fallible<()> {
     let mutagen_start = Instant::now();
 
-    let opt = Options::from_args();
+    // drop "mutagen" arg in cargo-subcommand mode
+    let mut args = env::args();
+    if env::var("CARGO").is_ok() {
+        // we're invoked by cargo, drop the first arg
+        args.next();
+    }
+    let opt = Options::from_iter(args);
 
     // build the testsuites and collect mutations
     let test_bins = compile_tests(&opt)?;


### PR DESCRIPTION
cargo passes all args to the subcommand program, which means our binary will receive "mutagen" as first argument when invoked like this:

     $ cargo mutagen

This produced an error, because structopt doesn't expect a "mutagen" argument at all:

     error: Found argument 'mutagen' which wasn't expected, or isn't
     valid in this context

     USAGE:
         cargo-mutagen [FLAGS] [OPTIONS]

         For more information try --help

For a similar problem, see rust-lang/rustfmt#3569.

This is how they handle it: https://github.com/rust-lang/rustfmt/blob/9124dd88d6ef14d0ae77dc52ff5e9598f24a75a0/rustfmt-core/rustfmt-bin/src/cargo-fmt/main.rs#L77

I've opted for a simpler solution because I don't think `mutagen` could be one of the arguments for `cargo-mutagen` currently (naming an eventual feature `mutagen` doesn't seem right). If you think this might be a problem later on, we can find a better fix :)