### PR TITLE
Pass through --package and --workspace arguments

### DIFF
--- a/mutagen-runner/src/main.rs
+++ b/mutagen-runner/src/main.rs
@@ -32,6 +32,14 @@ struct Options {
     /// Activate all available features
     #[structopt(long)]
     all_features: bool,
+
+    /// Package to run tests for
+    #[structopt(long, name = "SPEC")]
+    package: Option<String>,
+
+    /// Test all packages in the workspace
+    #[structopt(long)]
+    workspace: bool,
 }
 
 fn run() -> Fallible<()> {
@@ -132,6 +140,12 @@ fn compile_tests(opt: &Options) -> Fallible<Vec<PathBuf>> {
     }
     if opt.all_features {
         feature_args.push("--all-features");
+    }
+    if let Some(p) = &opt.package {
+        feature_args.extend(&["--package", p]);
+    }
+    if opt.workspace {
+        feature_args.push("--workspace");
     }
 
     // execute `cargo test --no-run --message-format=json` and collect output


### PR DESCRIPTION
I have a project with multiple crates in a workspace, with only the "inner" one needing mutation testing. The data in `target/mutagen` was generated when I ran `cargo test --workspace`, but cargo-mutagen didn't detect it unless I also passed `--workspace` to the `cargo test` that cargo-mutagen runs, so I made this patch to add the argument.

---

Commits:
* This commit adds the `--package` and `--workspace` arguments to cargo-mutagen. They're implemented in the same way as the `--features` and `--all-features` arguments, getting passed through to the `cargo test` invocation.