### PR TITLE
add license to Cargo.tomls

### DIFF
--- a/mutagen-core/Cargo.toml
+++ b/mutagen-core/Cargo.toml
@@ -3,6 +3,7 @@ name = "mutagen-core"
 version = "0.2.0"
 authors = ["Andre Bogus <bogusandre@gmail.com>", "Samuel Pilz <samuel.pilz@posteo.net>"]
 edition = "2018"
+license = "Apache-2.0/MIT"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/mutagen-runner/Cargo.toml
+++ b/mutagen-runner/Cargo.toml
@@ -3,6 +3,7 @@ name = "cargo-mutagen"
 version = "0.2.1"
 authors = ["Andre Bogus <bogusandre@gmail.com>", "Samuel Pilz <samuel.pilz@posteo.net>"]
 edition = "2018"
+license = "Apache-2.0/MIT"
 
 [dependencies]
 json = "0.12"

--- a/mutagen-selftest/Cargo.toml
+++ b/mutagen-selftest/Cargo.toml
@@ -3,6 +3,7 @@ name = "mutagen-selftest"
 version = "0.2.0"
 authors = ["Andre Bogus <bogusandre@gmail.com>", "Samuel Pilz <samuel.pilz@posteo.net>"]
 edition = "2018"
+license = "Apache-2.0/MIT"
 
 [dev-dependencies]
 mutagen = { path = "../mutagen" }

--- a/mutagen-transform/Cargo.toml
+++ b/mutagen-transform/Cargo.toml
@@ -3,6 +3,7 @@ name = "mutagen-transform"
 version = "0.2.0"
 authors = ["Andre Bogus <bogusandre@gmail.com>", "power-fungus <samuel.pilz@posteo.net>"]
 edition = "2018"
+license = "Apache-2.0/MIT"
 
 [dependencies]
 mutagen-core = { path = "../mutagen-core" }

--- a/mutagen/Cargo.toml
+++ b/mutagen/Cargo.toml
@@ -3,6 +3,7 @@ name = "mutagen"
 version = "0.2.0"
 authors = ["Andre Bogus <bogusandre@gmail.com>", "Samuel Pilz <samuel.pilz@posteo.net>"]
 edition = "2018"
+license = "Apache-2.0/MIT"
 
 [dependencies]
 mutagen-transform = { path = "../mutagen-transform" }


### PR DESCRIPTION
This is a prerequisite to finally publishing mutagen-0.2; it's been waiting for far too long.