### PR TITLE
Replace deprecated failure crate with anyhow

### DIFF
--- a/mutagen-core/Cargo.toml
+++ b/mutagen-core/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0/MIT"
 [dependencies]
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.68"
-failure = "0.1.8"
+anyhow = "1.0.57"
 json = "0.12.4"
 lazy_static = "1.4.0"
 

--- a/mutagen-core/src/comm/mutagen_files.rs
+++ b/mutagen-core/src/comm/mutagen_files.rs
@@ -1,4 +1,4 @@
-use failure::{bail, format_err, Fallible};
+use anyhow::{bail, Result, Context};
 use serde::{de::DeserializeOwned, Serialize};
 use std::fs::File;
 use std::io::{BufRead, BufReader, BufWriter, Write};
@@ -13,20 +13,20 @@ const JSON_MUTAGEN_FILENAME: &str = "mutations.json";
 const DEFAULT_COVERAGE_FILENAME: &str = "coverage";
 
 /// Finds the file that contains the descriptions of all mutations as written by the procedural macro
-pub fn get_mutations_file() -> Fallible<PathBuf> {
+pub fn get_mutations_file() -> Result<PathBuf> {
     Ok(mutagen_dir()?.join(DEFAULT_MUTAGEN_FILENAME))
 }
 
-pub fn get_mutations_file_json() -> Fallible<PathBuf> {
+pub fn get_mutations_file_json() -> Result<PathBuf> {
     Ok(mutagen_dir()?.join(JSON_MUTAGEN_FILENAME))
 }
 
-pub fn get_coverage_file() -> Fallible<PathBuf> {
+pub fn get_coverage_file() -> Result<PathBuf> {
     Ok(mutagen_dir()?.join(DEFAULT_COVERAGE_FILENAME))
 }
 
 /// queries `cargo` for the workspace root and locates the directory to write mutagen-specific information
-fn mutagen_dir() -> Fallible<PathBuf> {
+fn mutagen_dir() -> Result<PathBuf> {
     let metadata = Command::new("cargo").arg("metadata").output()?;
     if !metadata.status.success() {
         bail!("{}", str::from_utf8(&metadata.stderr)?);
@@ -35,21 +35,21 @@ fn mutagen_dir() -> Fallible<PathBuf> {
     let root_dir = Path::new(
         meta_json["workspace_root"]
             .as_str()
-            .ok_or_else(|| format_err!("cargo metadata misses workspace_root"))?,
+            .with_context(|| "cargo metadata misses workspace_root")?,
     );
     Ok(root_dir.join(DEFAULT_MUTAGEN_DIR))
 }
 
-pub fn read_items<T: DeserializeOwned>(filepath: &Path) -> Fallible<Vec<T>> {
+pub fn read_items<T: DeserializeOwned>(filepath: &Path) -> Result<Vec<T>> {
     BufReader::new(File::open(filepath)?)
         .lines()
         .map(|line| {
-            serde_json::from_str(&line?).map_err(|e| format_err!("mutation format error: {}", e))
+            serde_json::from_str(&line?).with_context(|| "mutation format error")
         })
         .collect()
 }
 
-pub fn append_item<T: Serialize + ?Sized>(file: &mut File, item: &T) -> Fallible<()> {
+pub fn append_item<T: Serialize + ?Sized>(file: &mut File, item: &T) -> Result<()> {
     let mut w = BufWriter::new(file);
     serde_json::to_writer(&mut w, item)?;
     writeln!(&mut w)?; // write newline

--- a/mutagen-core/src/comm/mutagen_files.rs
+++ b/mutagen-core/src/comm/mutagen_files.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result, Context};
+use anyhow::{bail, Context, Result};
 use serde::{de::DeserializeOwned, Serialize};
 use std::fs::File;
 use std::io::{BufRead, BufReader, BufWriter, Write};
@@ -43,9 +43,7 @@ fn mutagen_dir() -> Result<PathBuf> {
 pub fn read_items<T: DeserializeOwned>(filepath: &Path) -> Result<Vec<T>> {
     BufReader::new(File::open(filepath)?)
         .lines()
-        .map(|line| {
-            serde_json::from_str(&line?).with_context(|| "mutation format error")
-        })
+        .map(|line| serde_json::from_str(&line?).with_context(|| "mutation format error"))
         .collect()
 }
 

--- a/mutagen-runner/Cargo.toml
+++ b/mutagen-runner/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0/MIT"
 
 [dependencies]
 json = "0.12.4"
-failure = "0.1.8"
+anyhow = "1.0.57"
 wait-timeout = "0.2.0"
 serde_json = "1.0.68"
 mutagen-core = { path = "../mutagen-core"}

--- a/mutagen-runner/src/main.rs
+++ b/mutagen-runner/src/main.rs
@@ -1,4 +1,4 @@
-use failure::{bail, Fallible};
+use anyhow::{bail, Result};
 use std::collections::HashMap;
 use std::env;
 use std::fs::File;
@@ -42,7 +42,7 @@ struct Options {
     workspace: bool,
 }
 
-fn run() -> Fallible<()> {
+fn run() -> Result<()> {
     let mutagen_start = Instant::now();
 
     // drop "mutagen" arg in cargo-subcommand mode
@@ -76,7 +76,7 @@ fn run() -> Fallible<()> {
                 .map(|bin| Some(bin).filter(|bin| bin.coveres_any_mutation()))
                 .transpose()
         })
-        .collect::<Fallible<Vec<_>>>()?;
+        .collect::<Result<Vec<_>>>()?;
 
     let coverage = CoverageCollection::merge(num_mutations, test_bins.iter().map(|b| &b.coverage));
     progress.summary_testsuite_unmutated(coverage.num_covered())?;
@@ -102,7 +102,7 @@ fn run_mutations(
     test_bins: &[TestBinTested],
     mutations: Vec<BakedMutation>,
     coverage: &CoverageCollection,
-) -> Fallible<MutagenReport> {
+) -> Result<MutagenReport> {
     let mut mutagen_report = MutagenReport::new();
 
     for m in mutations {
@@ -131,7 +131,7 @@ fn run_mutations(
 }
 
 /// build all tests and collect test-suite executables
-fn compile_tests(opt: &Options) -> Fallible<Vec<PathBuf>> {
+fn compile_tests(opt: &Options) -> Result<Vec<PathBuf>> {
     let mut tests: Vec<PathBuf> = Vec::new();
 
     let mut feature_args: Vec<&str> = vec![];
@@ -195,7 +195,7 @@ fn compile_tests(opt: &Options) -> Fallible<Vec<PathBuf>> {
 ///
 /// This functions gets the file that describes all mutations performed on the target program and ensures that it exists.
 /// The list of mutations is also preserved
-fn read_mutations() -> Fallible<Vec<BakedMutation>> {
+fn read_mutations() -> Result<Vec<BakedMutation>> {
     let mutations_file = comm::get_mutations_file()?;
     if !mutations_file.exists() {
         bail!(

--- a/mutagen-runner/src/progress.rs
+++ b/mutagen-runner/src/progress.rs
@@ -7,7 +7,7 @@
 //! The main challenges is to be able to continue writing to the line above the progress bar.
 //! The output to the terminal should look identical to piped output but contains a progress bar.
 
-use failure::Fallible;
+use anyhow::Result;
 
 use std::path::Path;
 use std::time::Duration;
@@ -35,7 +35,7 @@ impl Progress {
     }
 
     /// Print summary information after the compilation of the test binaries.
-    pub fn summary_compile(&mut self, num_mutations: usize, num_testsuites: usize) -> Fallible<()> {
+    pub fn summary_compile(&mut self, num_mutations: usize, num_testsuites: usize) -> Result<()> {
         self.bar.println("")?;
         self.bar
             .println(&format!("Total mutations: {}", num_mutations))?;
@@ -46,14 +46,14 @@ impl Progress {
     }
 
     /// Start the section that runs the test suites unmutated.
-    pub fn section_testsuite_unmutated(&mut self, num_tests: usize) -> Fallible<()> {
+    pub fn section_testsuite_unmutated(&mut self, num_tests: usize) -> Result<()> {
         self.bar.println("")?;
         self.bar.println(&format!("Run {} tests", num_tests))?;
         Ok(())
     }
 
     /// start the section of test-runs for each mutation
-    pub fn section_mutants(&mut self) -> Fallible<()> {
+    pub fn section_mutants(&mut self) -> Result<()> {
         self.bar.println("")?;
         self.bar
             .println(&format!("Test {} Mutants", self.num_mutations))?;
@@ -61,14 +61,14 @@ impl Progress {
     }
 
     /// start the section of the
-    pub fn section_summary(&mut self) -> Fallible<()> {
+    pub fn section_summary(&mut self) -> Result<()> {
         self.bar.println("")?;
         self.bar.clear_bar()?;
         Ok(())
     }
 
     /// indicate the start of a run of a single testsuite without mutations
-    pub fn start_testsuite_unmutated(&mut self, bin: &Path, id: usize) -> Fallible<()> {
+    pub fn start_testsuite_unmutated(&mut self, bin: &Path, id: usize) -> Result<()> {
         let log_string = format!("{} ... ", bin.display());
         self.bar.print(log_string)?;
 
@@ -86,7 +86,7 @@ impl Progress {
     }
 
     /// indicate the end of a run of a single testsuite and display the result.
-    pub fn finish_testsuite_unmutated(&mut self, ok: bool, num_covered: usize) -> Fallible<()> {
+    pub fn finish_testsuite_unmutated(&mut self, ok: bool, num_covered: usize) -> Result<()> {
         if ok && num_covered > 0 {
             self.bar.println(&format!(
                 "ok ({}/{} covered)",
@@ -100,7 +100,7 @@ impl Progress {
     }
 
     /// print a summary after the testsuites have been run, especially coverage information.
-    pub fn summary_testsuite_unmutated(&mut self, num_covered: usize) -> Fallible<()> {
+    pub fn summary_testsuite_unmutated(&mut self, num_covered: usize) -> Result<()> {
         self.num_covered = num_covered;
         self.bar.set_total(num_covered);
 
@@ -115,7 +115,7 @@ impl Progress {
     ///
     /// The information about the mutation is logged to the console.
     /// A call to `finish_mutation` should follow a call to this function
-    pub fn start_mutation_covered(&mut self, m: &BakedMutation) -> Fallible<()> {
+    pub fn start_mutation_covered(&mut self, m: &BakedMutation) -> Result<()> {
         let mut mutant_log_string = mutation_log_string(m);
         mutant_log_string += " ... ";
 
@@ -141,7 +141,7 @@ impl Progress {
         Ok(())
     }
 
-    pub fn skip_mutation_uncovered(&mut self, m: &BakedMutation) -> Fallible<()> {
+    pub fn skip_mutation_uncovered(&mut self, m: &BakedMutation) -> Result<()> {
         self.bar.println(&format!(
             "{} ... {}",
             mutation_log_string(m),
@@ -152,7 +152,7 @@ impl Progress {
     /// indicate that a mutation started with `start_mutation` has been finished.
     ///
     /// The status is printed and progress bar is updated
-    pub fn finish_mutation(&mut self, status: MutantStatus) -> Fallible<()> {
+    pub fn finish_mutation(&mut self, status: MutantStatus) -> Result<()> {
         self.bar.println(&format!("{}", status))?;
         Ok(())
     }
@@ -160,7 +160,7 @@ impl Progress {
     /// indicate that mutation-testing is finished
     ///
     /// clears the progress-bar
-    pub fn finish(mut self, mutagen_time: Duration) -> Fallible<()> {
+    pub fn finish(mut self, mutagen_time: Duration) -> Result<()> {
         let rounded_time = Duration::from_secs(mutagen_time.as_secs());
         self.bar.println(&format!(
             "Total time: {}",

--- a/mutagen-runner/src/progress_bar.rs
+++ b/mutagen-runner/src/progress_bar.rs
@@ -6,8 +6,8 @@
 //!
 //! The main challenges is to be able to continue writing to the line above the progress bar.
 
-use console::Term;
 use anyhow::Result;
+use console::Term;
 use std::io::Write;
 
 /// Print progress during mutation testing

--- a/mutagen-runner/src/progress_bar.rs
+++ b/mutagen-runner/src/progress_bar.rs
@@ -7,7 +7,7 @@
 //! The main challenges is to be able to continue writing to the line above the progress bar.
 
 use console::Term;
-use failure::Fallible;
+use anyhow::Result;
 use std::io::Write;
 
 /// Print progress during mutation testing
@@ -55,7 +55,7 @@ impl ProgressBar {
     ///
     /// If the progress bar is shown, the text is printed above the progress bar.
     /// The next call to `println` will continue writing the line started by this function.
-    pub fn print(&mut self, s: String) -> Fallible<()> {
+    pub fn print(&mut self, s: String) -> Result<()> {
         if self.show_progress {
             self.term.clear_line()?;
         }
@@ -85,7 +85,7 @@ impl ProgressBar {
     /// prints a line to stdout.
     ///
     /// If the progress bar is shown, the line is printed above the progress bar.
-    pub fn println(&mut self, s: &str) -> Fallible<()> {
+    pub fn println(&mut self, s: &str) -> Result<()> {
         if self.show_progress {
             self.term.clear_line()?;
 
@@ -108,7 +108,7 @@ impl ProgressBar {
     }
 
     /// clears the progress bar
-    pub fn clear_bar(&mut self) -> Fallible<()> {
+    pub fn clear_bar(&mut self) -> Result<()> {
         if self.current_bar_state.take().is_some() {
             self.term.clear_line()?;
         }
@@ -118,7 +118,7 @@ impl ProgressBar {
     /// finish the progress bar
     ///
     /// clears the progress-indicator
-    pub fn finish(self) -> Fallible<()> {
+    pub fn finish(self) -> Result<()> {
         if self.show_progress {
             self.term.clear_line()?;
             writeln!(&self.term)?;
@@ -127,7 +127,7 @@ impl ProgressBar {
     }
 
     /// updates the state of the progress bar and draws the new state if the progress is shown
-    pub fn set_state(&mut self, bar: ProgressBarState) -> Fallible<()> {
+    pub fn set_state(&mut self, bar: ProgressBarState) -> Result<()> {
         if self.show_progress {
             self.current_bar_state = Some(bar);
             self.write_progress_bar()?;
@@ -135,7 +135,7 @@ impl ProgressBar {
         Ok(())
     }
 
-    fn write_progress_bar(&self) -> Fallible<()> {
+    fn write_progress_bar(&self) -> Result<()> {
         if let Some(bar) = &self.current_bar_state {
             if self.total == 0 {
                 return Ok(());

--- a/mutagen-runner/src/test_bin.rs
+++ b/mutagen-runner/src/test_bin.rs
@@ -1,4 +1,4 @@
-use failure::{bail, Fallible};
+use anyhow::{bail, Result};
 use std::fs;
 use std::io::Write;
 use std::path::Path;
@@ -36,7 +36,7 @@ impl<'a> TestBin<'a> {
         self,
         progress: &mut Progress,
         mutations: &[BakedMutation],
-    ) -> Fallible<TestBinTested<'a>> {
+    ) -> Result<TestBinTested<'a>> {
         let num_mutations = mutations.len();
         let test_start = Instant::now();
 
@@ -93,7 +93,7 @@ impl<'a> TestBinTested<'a> {
         self.coverage.num_covered() != 0
     }
 
-    pub fn check_mutant(&self, mutation: &BakedMutation) -> Fallible<MutantStatus> {
+    pub fn check_mutant(&self, mutation: &BakedMutation) -> Result<MutantStatus> {
         // run command and wait for its output
         let mut command = Command::new(self.test_bin.bin_path);
         command.env("MUTATION_ID", mutation.id().to_string());


### PR DESCRIPTION
This commit fixes #185 as mentioned in [Comparing Rust supply chain safety tools](https://blog.logrocket.com/comparing-rust-supply-chain-safety-tools/).